### PR TITLE
Re-enable and fix copy/paste tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,11 +69,12 @@ add_library(
   src/generated/xdg-shell-unstable-v6.c
   src/generated/xdg-shell.c
 
-  tests/copy_cut_paste.cpp
   tests/test_bad_buffer.cpp
+  tests/copy_cut_paste.cpp
   tests/test_surface_events.cpp
   tests/frame_submission.cpp
-        tests/self_test.cpp)
+  tests/self_test.cpp
+)
 
 target_link_libraries(
   wlcs

--- a/tests/copy_cut_paste.cpp
+++ b/tests/copy_cut_paste.cpp
@@ -65,7 +65,7 @@ struct MockDataDeviceListener : DataDeviceListener
 };
 }
 
-TEST_F(CopyCutPaste, DISABLED_given_source_has_offered_data_sink_sees_offer)
+TEST_F(CopyCutPaste, given_source_has_offered_data_sink_sees_offer)
 {
     DataSource source_data{wl_data_device_manager_create_data_source(source.data_device_manager())};
     wl_data_source_offer(source_data, any_mime_type);

--- a/tests/copy_cut_paste.cpp
+++ b/tests/copy_cut_paste.cpp
@@ -28,15 +28,10 @@
 using namespace testing;
 using namespace wlcs;
 
+using CopyCutPaste = wlcs::InProcessServer;
+
 namespace
 {
-struct StartedInProcessServer : InProcessServer
-{
-    StartedInProcessServer() { InProcessServer::SetUp(); }
-
-    void SetUp() override {}
-};
-
 auto static const any_width = 100;
 auto static const any_height = 100;
 auto static const any_mime_type = "AnyMimeType";
@@ -65,11 +60,6 @@ struct CCnPClient : Client
     std::shared_ptr<ShmBuffer> const buffer{std::make_shared<ShmBuffer>(*this, any_width, any_height)};
 };
 
-struct CopyCutPaste : StartedInProcessServer
-{
-    CCnPClient source{the_server()};
-};
-
 struct MockDataDeviceListener : DataDeviceListener
 {
     using DataDeviceListener::DataDeviceListener;
@@ -80,6 +70,7 @@ struct MockDataDeviceListener : DataDeviceListener
 
 TEST_F(CopyCutPaste, given_source_has_offered_data_sink_sees_offer)
 {
+    CCnPClient source{the_server()};
     DataSource source_data{wl_data_device_manager_create_data_source(source.data_device_manager())};
     wl_data_source_offer(source_data, any_mime_type);
     source.roundtrip();


### PR DESCRIPTION
The copy/paste test had been disabled as a workaround for #30. The real problem is running *any* tests that send buffers before the bad buffer tests, so I simply moved the copy/paste one in CMake and re-enabled it.

commit bcdc705509e78bd6752cd4bd2af145f1e123115c broke the copy/paste test by causing `Client::create_visible_surface()` to block while the needed callbacks were called (thus they were called before the listener was installed). I resolved this issue by manually inlining some of `create_visible_surface()` into `CCnPClient`.