### PR TITLE
Subsurface input tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ add_library(
   tests/test_surface_events.cpp
   tests/surface_input_regions.cpp
   tests/frame_submission.cpp
+  tests/subsurfaces.cpp
   tests/xdg_surface_v6.cpp
   tests/xdg_toplevel_v6.cpp
   tests/self_test.cpp

--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -96,7 +96,10 @@ private:
 class Subsurface: public Surface
 {
 public:
+    static Subsurface create_visible(Surface& parent, int x, int y, int width, int height);
+
     Subsurface(Surface& parent);
+    Subsurface(Subsurface &&);
     ~Subsurface();
 
     operator wl_subsurface*() const;

--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -93,6 +93,21 @@ private:
     std::unique_ptr<Impl> impl;
 };
 
+class Subsurface: public Surface
+{
+public:
+    Subsurface(Surface& parent);
+    ~Subsurface();
+
+    operator wl_subsurface*() const;
+
+    Surface& parent();
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> impl;
+};
+
 class ShmBuffer
 {
 public:
@@ -121,6 +136,7 @@ public:
     operator wl_display*() const;
 
     wl_compositor* compositor() const;
+    wl_subcompositor* subcompositor() const;
     wl_shm* shm() const;
     wl_data_device_manager* data_device_manager() const;
     wl_seat* seat() const;

--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -224,6 +224,16 @@ private:
     Server server;
 };
 
+class StartedInProcessServer : public InProcessServer
+{
+public:
+    StartedInProcessServer() { InProcessServer::SetUp(); }
+    ~StartedInProcessServer() { InProcessServer::TearDown(); }
+
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
 }
 
 #endif //WLCS_IN_PROCESS_SERVER_H_

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -260,6 +260,7 @@ public:
         if (shm) wl_shm_destroy(shm);
         if (shell) wl_shell_destroy(shell);
         if (compositor) wl_compositor_destroy(compositor);
+        if (subcompositor) wl_subcompositor_destroy(subcompositor);
         if (registry) wl_registry_destroy(registry);
         for (auto shell_surface: wl_shell_surfaces) wl_shell_surface_destroy(shell_surface);
         wl_shell_surfaces.clear();
@@ -279,6 +280,11 @@ public:
     struct wl_compositor* wl_compositor() const
     {
         return compositor;
+    }
+
+    struct wl_subcompositor* wl_subcompositor() const
+    {
+        return subcompositor;
     }
 
     struct wl_shm* wl_shm() const
@@ -580,6 +586,11 @@ private:
             me->compositor = static_cast<struct wl_compositor*>(
                 wl_registry_bind(registry, id, &wl_compositor_interface, version));
         }
+        else if ("wl_subcompositor"s == interface)
+        {
+            me->subcompositor = static_cast<struct wl_subcompositor*>(
+                wl_registry_bind(registry, id, &wl_subcompositor_interface, version));
+        }
         else if ("wl_shell"s == interface)
         {
             me->shell = static_cast<struct wl_shell*>(
@@ -624,6 +635,7 @@ private:
     struct wl_display* display;
     struct wl_registry* registry = nullptr;
     struct wl_compositor* compositor = nullptr;
+    struct wl_subcompositor* subcompositor = nullptr;
     struct wl_shm* shm = nullptr;
     std::vector<struct wl_shell_surface*> wl_shell_surfaces;
     struct wl_shell* shell = nullptr;
@@ -666,6 +678,11 @@ wlcs::Client::operator wl_display*() const
 wl_compositor* wlcs::Client::compositor() const
 {
     return impl->wl_compositor();
+}
+
+wl_subcompositor* wlcs::Client::subcompositor() const
+{
+    return impl->wl_subcompositor();
 }
 
 wl_shm* wlcs::Client::shm() const
@@ -854,6 +871,37 @@ void wlcs::Surface::add_frame_callback(std::function<void(int)> const& on_frame)
 wlcs::Client& wlcs::Surface::owner() const
 {
     return impl->owner();
+}
+
+class wlcs::Subsurface::Impl
+{
+public:
+    Impl(Client& client, Surface& surface, Surface& parent)
+        : subsurface_{wl_subcompositor_get_subsurface(client.subcompositor(), surface, parent)},
+          parent_{parent}
+    {
+    }
+
+    struct wl_subsurface* const subsurface_;
+    Surface& parent_;
+};
+
+wlcs::Subsurface::Subsurface(wlcs::Surface& parent)
+    : Surface{parent.owner()},
+      impl{std::make_unique<wlcs::Subsurface::Impl>(parent.owner(), *this, parent)}
+{
+}
+
+wlcs::Subsurface::~Subsurface() = default;
+
+wlcs::Subsurface::operator wl_subsurface*() const
+{
+    return impl->subsurface_;
+}
+
+wlcs::Surface& wlcs::Subsurface::parent()
+{
+    return impl->parent_;
 }
 
 class wlcs::ShmBuffer::Impl

--- a/tests/copy_cut_paste.cpp
+++ b/tests/copy_cut_paste.cpp
@@ -29,12 +29,6 @@ using namespace wlcs;
 
 namespace
 {
-struct StartedInProcessServer : InProcessServer
-{
-    StartedInProcessServer() { InProcessServer::SetUp(); }
-
-    void SetUp() override {}
-};
 
 auto static const any_width = 100;
 auto static const any_height = 100;

--- a/tests/subsurfaces.cpp
+++ b/tests/subsurfaces.cpp
@@ -37,7 +37,7 @@ TEST_F(SubsurfaceTest, subsurface_can_be_created)
     EXPECT_THAT(&subsurface.parent(), Eq(&main_surface));
 }
 
-TEST_F(SubsurfaceTest, subsurface_gets_pointer_input)
+TEST_F(SubsurfaceTest, gets_pointer_input)
 {
     wlcs::Client client{the_server()};
     wlcs::Surface main_surface{client.create_visible_surface(200, 300)};
@@ -59,7 +59,7 @@ TEST_F(SubsurfaceTest, subsurface_gets_pointer_input)
                     wl_fixed_from_int(5))));
 }
 
-TEST_F(SubsurfaceTest, subsurface_pointer_input_offset)
+TEST_F(SubsurfaceTest, pointer_input_offset)
 {
     wlcs::Client client{the_server()};
     wlcs::Surface main_surface{client.create_visible_surface(200, 300)};
@@ -81,7 +81,30 @@ TEST_F(SubsurfaceTest, subsurface_pointer_input_offset)
                     wl_fixed_from_int(13))));
 }
 
-TEST_F(SubsurfaceTest, subsurface_empty_input_region_fallthrough)
+// appears to work in normal Mir, but breaks in WLCS
+TEST_F(SubsurfaceTest, DISABLED_extends_parent_region)
+{
+    wlcs::Client client{the_server()};
+    wlcs::Surface main_surface{client.create_visible_surface(200, 300)};
+
+    the_server().move_surface_to(main_surface, 20, 30);
+    client.roundtrip();
+
+    auto subsurface{wlcs::Subsurface::create_visible(main_surface, -10, 275, 50, 50)};
+
+    auto pointer = the_server().create_pointer();
+    pointer.move_to(15, 340);
+    client.roundtrip();
+
+    EXPECT_THAT(client.focused_window(), Ne((wl_surface*)main_surface)) << "input fell through to main surface";
+    EXPECT_THAT(client.focused_window(), Eq((wl_surface*)subsurface));
+    EXPECT_THAT(client.pointer_position(),
+                Eq(std::make_pair(
+                    wl_fixed_from_int(5),
+                    wl_fixed_from_int(35))));
+}
+
+TEST_F(SubsurfaceTest, empty_input_region_fallthrough)
 {
     wlcs::Client client{the_server()};
     wlcs::Surface main_surface{client.create_visible_surface(200, 300)};
@@ -109,7 +132,7 @@ TEST_F(SubsurfaceTest, subsurface_empty_input_region_fallthrough)
                     wl_fixed_from_int(10))));
 }
 
-TEST_F(SubsurfaceTest, subsurface_gets_input_over_surface_with_empty_region)
+TEST_F(SubsurfaceTest, gets_input_over_surface_with_empty_region)
 {
     wlcs::Client client{the_server()};
     wlcs::Surface main_surface{client.create_visible_surface(200, 300)};
@@ -137,8 +160,7 @@ TEST_F(SubsurfaceTest, subsurface_gets_input_over_surface_with_empty_region)
                     wl_fixed_from_int(13))));
 }
 
-// TODO: William will submit PR to Mir that fixes tested behavior. Enable when that lands.
-TEST_F(SubsurfaceTest, DISABLED_one_subsurface_to_another_fallthrough)
+TEST_F(SubsurfaceTest, one_subsurface_to_another_fallthrough)
 {
     wlcs::Client client{the_server()};
     wlcs::Surface main_surface{client.create_visible_surface(200, 300)};

--- a/tests/subsurfaces.cpp
+++ b/tests/subsurfaces.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2018 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <williamwold@canonical.com>
+ */
+
+#include "helpers.h"
+#include "in_process_server.h"
+#include "xdg_shell_v6.h"
+
+#include <gmock/gmock.h>
+
+#include <vector>
+
+using namespace testing;
+
+using SubsurfaceTest = wlcs::InProcessServer;
+
+TEST_F(SubsurfaceTest, subsurface_can_be_created)
+{
+    wlcs::Client client{the_server()};
+    ASSERT_THAT(client.subcompositor(), NotNull());
+    wlcs::Surface main_surface{client.create_visible_surface(200, 300)};
+    wlcs::Subsurface subsurface{main_surface};
+    EXPECT_THAT(&subsurface.parent(), Eq(&main_surface));
+}
+
+TEST_F(SubsurfaceTest, subsurface_gets_pointer_input)
+{
+    wlcs::Client client{the_server()};
+    wlcs::Surface main_surface{client.create_visible_surface(200, 300)};
+
+    the_server().move_surface_to(main_surface, 20, 30);
+    client.roundtrip();
+
+    auto subsurface{wlcs::Subsurface::create_visible(main_surface, 0, 0, 50, 50)};
+
+    auto pointer = the_server().create_pointer();
+    pointer.move_to(30, 35);
+    client.roundtrip();
+
+    EXPECT_THAT(client.focused_window(), Ne((wl_surface*)main_surface)) << "input fell through to main surface";
+    EXPECT_THAT(client.focused_window(), Eq((wl_surface*)subsurface));
+    EXPECT_THAT(client.pointer_position(),
+                Eq(std::make_pair(
+                    wl_fixed_from_int(10),
+                    wl_fixed_from_int(5))));
+}
+
+TEST_F(SubsurfaceTest, subsurface_pointer_input_offset)
+{
+    wlcs::Client client{the_server()};
+    wlcs::Surface main_surface{client.create_visible_surface(200, 300)};
+
+    the_server().move_surface_to(main_surface, 20, 30);
+    client.roundtrip();
+
+    auto subsurface{wlcs::Subsurface::create_visible(main_surface, 8, 17, 50, 50)};
+
+    auto pointer = the_server().create_pointer();
+    pointer.move_to(35, 60);
+    client.roundtrip();
+
+    EXPECT_THAT(client.focused_window(), Ne((wl_surface*)main_surface)) << "input fell through to main surface";
+    EXPECT_THAT(client.focused_window(), Eq((wl_surface*)subsurface));
+    EXPECT_THAT(client.pointer_position(),
+                Eq(std::make_pair(
+                    wl_fixed_from_int(7),
+                    wl_fixed_from_int(13))));
+}
+
+TEST_F(SubsurfaceTest, subsurface_empty_input_region_fallthrough)
+{
+    wlcs::Client client{the_server()};
+    wlcs::Surface main_surface{client.create_visible_surface(200, 300)};
+
+    the_server().move_surface_to(main_surface, 20, 30);
+    client.roundtrip();
+
+    auto subsurface{wlcs::Subsurface::create_visible(main_surface, 5, 5, 50, 50)};
+    auto const wl_region = wl_compositor_create_region(client.compositor());
+    wl_surface_set_input_region(subsurface, wl_region);
+    wl_region_destroy(wl_region);
+    wl_surface_commit(subsurface);
+    wl_surface_commit(main_surface);
+    client.roundtrip();
+
+    auto pointer = the_server().create_pointer();
+    pointer.move_to(30, 40);
+    client.roundtrip();
+
+    EXPECT_THAT(client.focused_window(), Ne((wl_surface*)subsurface)) << "input was incorrectly caught by subsurface";
+    EXPECT_THAT(client.focused_window(), Eq((wl_surface*)main_surface));
+    EXPECT_THAT(client.pointer_position(),
+                Eq(std::make_pair(
+                    wl_fixed_from_int(10),
+                    wl_fixed_from_int(10))));
+}
+
+TEST_F(SubsurfaceTest, subsurface_gets_input_over_surface_with_empty_region)
+{
+    wlcs::Client client{the_server()};
+    wlcs::Surface main_surface{client.create_visible_surface(200, 300)};
+
+    the_server().move_surface_to(main_surface, 20, 30);
+    client.roundtrip();
+
+    auto subsurface{wlcs::Subsurface::create_visible(main_surface, 8, 17, 50, 50)};
+
+    auto const wl_region = wl_compositor_create_region(client.compositor());
+    wl_surface_set_input_region(main_surface, wl_region);
+    wl_region_destroy(wl_region);
+    wl_surface_commit(main_surface);
+    client.roundtrip();
+
+    auto pointer = the_server().create_pointer();
+    pointer.move_to(35, 60);
+    client.roundtrip();
+
+    EXPECT_THAT(client.focused_window(), Ne((wl_surface*)main_surface)) << "input fell through to main surface";
+    EXPECT_THAT(client.focused_window(), Eq((wl_surface*)subsurface));
+    EXPECT_THAT(client.pointer_position(),
+                Eq(std::make_pair(
+                    wl_fixed_from_int(7),
+                    wl_fixed_from_int(13))));
+}
+
+// TODO: William will submit PR to Mir that fixes tested behavior. Enable when that lands.
+TEST_F(SubsurfaceTest, DISABLED_one_subsurface_to_another_fallthrough)
+{
+    wlcs::Client client{the_server()};
+    wlcs::Surface main_surface{client.create_visible_surface(200, 300)};
+
+    the_server().move_surface_to(main_surface, 20, 30);
+    client.roundtrip();
+
+    auto subsurface_bottom{wlcs::Subsurface::create_visible(main_surface, 0, 5, 50, 50)};
+    auto subsurface_top{wlcs::Subsurface::create_visible(main_surface, 0, 0, 50, 50)};
+
+    auto const wl_region = wl_compositor_create_region(client.compositor());
+    wl_region_add(wl_region, 20, 0, 30, 50);
+    wl_surface_set_input_region(subsurface_top, wl_region);
+    wl_region_destroy(wl_region);
+    wl_surface_commit(subsurface_top);
+    wl_surface_commit(main_surface);
+    client.roundtrip();
+
+    auto pointer = the_server().create_pointer();
+
+    pointer.move_to(30, 33);
+    client.roundtrip();
+
+    EXPECT_THAT(client.focused_window(), Eq((wl_surface*)main_surface)) << "main surface not focused";
+    EXPECT_THAT(client.pointer_position(),
+                Eq(std::make_pair(
+                    wl_fixed_from_int(10),
+                    wl_fixed_from_int(3))));
+
+    pointer.move_to(30, 40);
+    client.roundtrip();
+
+    EXPECT_THAT(client.focused_window(), Eq((wl_surface*)subsurface_bottom)) << "lower subsurface not focused";
+    EXPECT_THAT(client.pointer_position(),
+                Eq(std::make_pair(
+                    wl_fixed_from_int(10),
+                    wl_fixed_from_int(5))));
+
+    pointer.move_to(50, 40);
+    client.roundtrip();
+
+    EXPECT_THAT(client.focused_window(), Eq((wl_surface*)subsurface_top)) << "upper subsurface not focused";
+    EXPECT_THAT(client.pointer_position(),
+                Eq(std::make_pair(
+                    wl_fixed_from_int(30),
+                    wl_fixed_from_int(10))));
+}
+
+// TODO: subsurface reordering
+
+// TODO: sync and desync

--- a/tests/subsurfaces.cpp
+++ b/tests/subsurfaces.cpp
@@ -52,12 +52,12 @@ public:
     wlcs::Subsurface subsurface{wlcs::Subsurface::create_visible(main_surface, 0, 0, subsurface_width, subsurface_height)};
 };
 
-TEST_F(SubsurfaceTest, subsurface_can_be_created)
+TEST_F(SubsurfaceTest, subsurface_has_correct_parent)
 {
     EXPECT_THAT(&subsurface.parent(), Eq(&main_surface));
 }
 
-TEST_F(SubsurfaceTest, gets_pointer_input)
+TEST_F(SubsurfaceTest, subsurface_gets_pointer_input)
 {
     int const pointer_x = surface_x + 10, pointer_y = surface_y + 5;
 
@@ -73,7 +73,7 @@ TEST_F(SubsurfaceTest, gets_pointer_input)
                     wl_fixed_from_int(pointer_y - surface_y))));
 }
 
-TEST_F(SubsurfaceTest, pointer_input_offset)
+TEST_F(SubsurfaceTest, pointer_input_correctly_offset_for_subsurface)
 {
     int const pointer_x = surface_x + 13, pointer_y = surface_y + 24;
     int const subsurface_x = 8, subsurface_y = 17;
@@ -95,8 +95,7 @@ TEST_F(SubsurfaceTest, pointer_input_offset)
                     wl_fixed_from_int(pointer_y - surface_y - subsurface_y))));
 }
 
-// appears to work in normal Mir, but breaks in WLCS
-TEST_F(SubsurfaceTest, extends_parent_region)
+TEST_F(SubsurfaceTest, subsurface_extends_parent_input_region)
 {
     int const pointer_x = surface_x - 5, pointer_y = surface_y + surface_height + 8;
     int const subsurface_x = -10, subsurface_y = surface_height - 10;
@@ -115,7 +114,7 @@ TEST_F(SubsurfaceTest, extends_parent_region)
                     wl_fixed_from_int(pointer_y - surface_y - subsurface_y))));
 }
 
-TEST_F(SubsurfaceTest, empty_input_region_fallthrough)
+TEST_F(SubsurfaceTest, input_falls_through_empty_subsurface_input_region)
 {
     int const pointer_x = surface_x + 10, pointer_y = surface_y + 5;
 
@@ -210,6 +209,6 @@ TEST_F(SubsurfaceTest, one_subsurface_to_another_fallthrough)
 
 // TODO: subsurface of subsurface
 
-// TODO: subsurface reordering
+// TODO: subsurface reordering (not in Mir yet)
 
 // TODO: sync and desync


### PR DESCRIPTION
Will not compile until the Surface::attach_buffer() PR lands.