### PR TITLE
Resolve ${GMOCK_INCLUDE_DIR} on Ubuntu 18.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,11 +50,12 @@ find_package(GtestGmock)
 pkg_check_modules(WAYLAND_CLIENT REQUIRED wayland-client)
 
 include_directories(include)
+include_directories(${GMOCK_INCLUDE_DIR} ${GTEST_INCLUDE_DIR})
 
 add_subdirectory(src/protocol/)
 
 add_library(
-  wlcs SHARED
+  wlcs STATIC
 
   include/display_server.h
   include/helpers.h

--- a/cmake/FindGtestGmock.cmake
+++ b/cmake/FindGtestGmock.cmake
@@ -45,7 +45,7 @@ find_file(GMOCK_SOURCE
         PATHS /usr/src/googletest/googlemock/src/ /usr/src/gmock/ /usr/src/gmock/src)
 
 if (EXISTS ${GMOCK_SOURCE})
-    find_path(GMOCK_INCLUDE_DIR gmock/gmock.h)
+    find_path(GMOCK_INCLUDE_DIR gmock/gmock.h PATHS ${GMOCK_SOURCE}/include)
 
     add_library(GMock STATIC ${GMOCK_SOURCE})
 


### PR DESCRIPTION
More fixes are required in Mir, but this is the wlcs pre-requsite.