### PR TITLE
Xdg toplevel v6 cleanup

### DIFF
--- a/tests/xdg_toplevel_v6.cpp
+++ b/tests/xdg_toplevel_v6.cpp
@@ -33,191 +33,135 @@
 
 #include <experimental/optional>
 
-using XdgToplevelV6Test = wlcs::InProcessServer;
+using XdgToplevelV6Configuration = wlcs::InProcessServer;
 
 class XdgToplevelWindow
 {
 public:
+    int const window_width = 200, window_height = 320;
+
     XdgToplevelWindow(wlcs::Server& server)
         : client{server},
           surface{client},
           xdg_surface{client, surface},
           toplevel{xdg_surface}
-    {}
+    {
+        xdg_surface.add_configure_notification([&](uint32_t serial)
+            {
+                zxdg_surface_v6_ack_configure(xdg_surface, serial);
+                surface_configure_count++;
+            });
+
+        toplevel.add_configure_notification([this] (int32_t width, int32_t height, struct wl_array *states)
+            {
+                state = wlcs::XdgToplevelV6::State{width, height, states};
+            });
+
+        wl_surface_commit(surface);
+        client.roundtrip();
+        surface.attach_buffer(window_width, window_height);
+        wl_surface_commit(surface);
+        dispatch_until_configure();
+    }
 
     ~XdgToplevelWindow()
     {
         client.roundtrip();
     }
 
+    void dispatch_until_configure()
+    {
+        client.dispatch_until(
+            [prev_count = surface_configure_count, &current_count = surface_configure_count]()
+            {
+                return current_count > prev_count;
+            });
+    }
+
     wlcs::Client client;
     wlcs::Surface surface;
     wlcs::XdgSurfaceV6 xdg_surface;
     wlcs::XdgToplevelV6 toplevel;
+
+    int surface_configure_count{0};
+    std::experimental::optional<wlcs::XdgToplevelV6::State> state;
 };
 
-TEST_F(XdgToplevelV6Test, default_configuration)
+TEST_F(XdgToplevelV6Configuration, default)
 {
     using namespace testing;
 
     XdgToplevelWindow window{the_server()};
-
-    int surface_configure_count{0};
-    window.xdg_surface.add_configure_notification([&](uint32_t serial)
-        {
-            zxdg_surface_v6_ack_configure(window.xdg_surface, serial);
-            surface_configure_count++;
-        });
-
-    std::experimental::optional<wlcs::XdgToplevelV6::State> state;
-    window.toplevel.add_configure_notification([&state] (int32_t width, int32_t height, struct wl_array *states)
-        {
-            state = wlcs::XdgToplevelV6::State{width, height, states};
-        });
-
-    wl_surface_commit(window.surface);
-    window.client.roundtrip();
-    window.surface.attach_buffer(600, 400);
-    wl_surface_commit(window.surface);
-
-    window.client.dispatch_until(
-        [prev_count = surface_configure_count, &current_count = surface_configure_count]()
-        {
-            return current_count > prev_count;
-        });
 
     // default values
-    ASSERT_THAT(state, Ne(std::experimental::nullopt));
-    EXPECT_THAT(state.value().width, Eq(0));
-    EXPECT_THAT(state.value().height, Eq(0));
-    EXPECT_THAT(state.value().maximized, Eq(false));
-    EXPECT_THAT(state.value().fullscreen, Eq(false));
-    EXPECT_THAT(state.value().resizing, Eq(false));
-    EXPECT_THAT(state.value().activated, Eq(true));
+    ASSERT_THAT(window.state, Ne(std::experimental::nullopt));
+    auto state = window.state.value();
+    EXPECT_THAT(state.width, Eq(0));
+    EXPECT_THAT(state.height, Eq(0));
+    EXPECT_THAT(state.maximized, Eq(false));
+    EXPECT_THAT(state.fullscreen, Eq(false));
+    EXPECT_THAT(state.resizing, Eq(false));
+    EXPECT_THAT(state.activated, Eq(true));
 }
 
-TEST_F(XdgToplevelV6Test, correct_configuration_when_maximized_and_unmaximized)
+TEST_F(XdgToplevelV6Configuration, maximized_and_unmaximized)
 {
     using namespace testing;
 
     XdgToplevelWindow window{the_server()};
-
-    int surface_configure_count{0};
-    window.xdg_surface.add_configure_notification([&](uint32_t serial)
-        {
-            zxdg_surface_v6_ack_configure(window.xdg_surface, serial);
-            surface_configure_count++;
-        });
-
-    std::experimental::optional<wlcs::XdgToplevelV6::State> state;
-    window.toplevel.add_configure_notification([&state] (int32_t width, int32_t height, struct wl_array *states)
-        {
-            state = wlcs::XdgToplevelV6::State{width, height, states};
-        });
-
-    wl_surface_commit(window.surface);
-    window.client.roundtrip();
-    window.surface.attach_buffer(200, 200);
-    wl_surface_commit(window.surface);
-
-    window.client.dispatch_until(
-        [prev_count = surface_configure_count, &current_count = surface_configure_count]()
-        {
-            return current_count > prev_count;
-        });
 
     zxdg_toplevel_v6_set_maximized(window.toplevel);
     wl_surface_commit(window.surface);
+    window.dispatch_until_configure();
 
-    window.client.dispatch_until(
-        [prev_count = surface_configure_count, &current_count = surface_configure_count]()
-        {
-            return current_count > prev_count;
-        });
-
-    ASSERT_THAT(state, Ne(std::experimental::nullopt));
-    EXPECT_THAT(state.value().width, Gt(0));
-    EXPECT_THAT(state.value().height, Gt(0));
-    EXPECT_THAT(state.value().maximized, Eq(true));
-    EXPECT_THAT(state.value().fullscreen, Eq(false));
-    EXPECT_THAT(state.value().resizing, Eq(false));
-    EXPECT_THAT(state.value().activated, Eq(true));
+    ASSERT_THAT(window.state, Ne(std::experimental::nullopt));
+    auto state = window.state.value();
+    EXPECT_THAT(state.width, Gt(0));
+    EXPECT_THAT(state.height, Gt(0));
+    EXPECT_THAT(state.maximized, Eq(true));
+    EXPECT_THAT(state.fullscreen, Eq(false));
+    EXPECT_THAT(state.resizing, Eq(false));
+    EXPECT_THAT(state.activated, Eq(true));
 
     zxdg_toplevel_v6_unset_maximized(window.toplevel);
     wl_surface_commit(window.surface);
+    window.dispatch_until_configure();
 
-    window.client.dispatch_until(
-        [prev_count = surface_configure_count, &current_count = surface_configure_count]()
-        {
-            return current_count > prev_count;
-        });
-
-    ASSERT_THAT(state, Ne(std::experimental::nullopt));
-    EXPECT_THAT(state.value().maximized, Eq(false));
-    EXPECT_THAT(state.value().fullscreen, Eq(false));
-    EXPECT_THAT(state.value().resizing, Eq(false));
-    EXPECT_THAT(state.value().activated, Eq(true));
+    ASSERT_THAT(window.state, Ne(std::experimental::nullopt));
+    state = window.state.value();
+    EXPECT_THAT(state.maximized, Eq(false));
+    EXPECT_THAT(state.fullscreen, Eq(false));
+    EXPECT_THAT(state.resizing, Eq(false));
+    EXPECT_THAT(state.activated, Eq(true));
 }
 
-TEST_F(XdgToplevelV6Test, correct_configuration_when_fullscreened_and_restored)
+TEST_F(XdgToplevelV6Configuration, fullscreened_and_restored)
 {
     using namespace testing;
 
     XdgToplevelWindow window{the_server()};
 
-    int surface_configure_count{0};
-    window.xdg_surface.add_configure_notification([&](uint32_t serial)
-        {
-            zxdg_surface_v6_ack_configure(window.xdg_surface, serial);
-            surface_configure_count++;
-        });
-
-    std::experimental::optional<wlcs::XdgToplevelV6::State> state;
-    window.toplevel.add_configure_notification([&state] (int32_t width, int32_t height, struct wl_array *states)
-        {
-            state = wlcs::XdgToplevelV6::State{width, height, states};
-        });
-
-    wl_surface_commit(window.surface);
-    window.client.roundtrip();
-    window.surface.attach_buffer(200, 200);
-    wl_surface_commit(window.surface);
-
-    window.client.dispatch_until(
-        [prev_count = surface_configure_count, &current_count = surface_configure_count]()
-        {
-            return current_count > prev_count;
-        });
-
     zxdg_toplevel_v6_set_fullscreen(window.toplevel, nullptr);
     wl_surface_commit(window.surface);
+    window.dispatch_until_configure();
 
-    window.client.dispatch_until(
-        [prev_count = surface_configure_count, &current_count = surface_configure_count]()
-        {
-            return current_count > prev_count;
-        });
-
-    ASSERT_THAT(state, Ne(std::experimental::nullopt));
-    EXPECT_THAT(state.value().width, Gt(0));
-    EXPECT_THAT(state.value().height, Gt(0));
-    EXPECT_THAT(state.value().maximized, Eq(false)); // is this right? should it not be maximized, even when fullscreen?
-    EXPECT_THAT(state.value().fullscreen, Eq(true));
-    EXPECT_THAT(state.value().resizing, Eq(false));
-    EXPECT_THAT(state.value().activated, Eq(true));
+    ASSERT_THAT(window.state, Ne(std::experimental::nullopt));
+    auto state = window.state.value();
+    EXPECT_THAT(state.width, Gt(0));
+    EXPECT_THAT(state.height, Gt(0));
+    EXPECT_THAT(state.maximized, Eq(false)); // is this right? should it not be maximized, even when fullscreen?
+    EXPECT_THAT(state.fullscreen, Eq(true));
+    EXPECT_THAT(state.resizing, Eq(false));
+    EXPECT_THAT(state.activated, Eq(true));
 
     zxdg_toplevel_v6_unset_fullscreen(window.toplevel);
     wl_surface_commit(window.surface);
+    window.dispatch_until_configure();
 
-    window.client.dispatch_until(
-        [prev_count = surface_configure_count, &current_count = surface_configure_count]()
-        {
-            return current_count > prev_count;
-        });
-
-    ASSERT_THAT(state, Ne(std::experimental::nullopt));
-    EXPECT_THAT(state.value().maximized, Eq(false));
-    EXPECT_THAT(state.value().fullscreen, Eq(false));
-    EXPECT_THAT(state.value().resizing, Eq(false));
-    EXPECT_THAT(state.value().activated, Eq(true));
+    ASSERT_THAT(window.state, Ne(std::experimental::nullopt));
+    state = window.state.value();
+    EXPECT_THAT(state.maximized, Eq(false));
+    EXPECT_THAT(state.fullscreen, Eq(false));
+    EXPECT_THAT(state.resizing, Eq(false));
+    EXPECT_THAT(state.activated, Eq(true));
 }


### PR DESCRIPTION
Cleaned up boilerplate in XDG toplevel tests. I'm aware that I was advised against this last time I tried to do it, but maybe this is better since its still in the test file? Discuss.