### PR TITLE
added create_wl_shell_surface() and create_xdg_shell_surface()

### DIFF
--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -166,6 +166,8 @@ public:
     wl_seat* seat() const;
 
     ShmBuffer const& create_buffer(int width, int height);
+    Surface create_wl_shell_surface(int width, int height);
+    Surface create_xdg_shell_v6_surface(int width, int height);
     Surface create_visible_surface(int width, int height);
 
     wl_shell* shell() const;


### PR DESCRIPTION
These are drop in replacements for `create_visible()`, which now uses `create_wl_shell_surface()`