### PR TITLE
Fixed XdgSurfaceV6Test.gets_configure_event to test correct behavior

### DIFF
--- a/tests/xdg_surface_v6.cpp
+++ b/tests/xdg_surface_v6.cpp
@@ -60,11 +60,5 @@ TEST_F(XdgSurfaceV6Test, gets_configure_event)
 
     client.roundtrip();
 
-    EXPECT_THAT(surface_configure_count, Eq(0));
-
-    wl_surface_commit(surface);
-
-    client.roundtrip();
-
     EXPECT_THAT(surface_configure_count, Eq(1));
 }


### PR DESCRIPTION
This goes with (this PR to Mir)[]