### PR TITLE
Support dynamically marking tests as expected failures.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ set(
   src/shared_library.cpp
   src/xfail_supporting_test_listener.h
   src/xfail_supporting_test_listener.cpp
+  src/termcolor.hpp
 
   ${PROTOCOL_SOURCES}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,8 @@ set(
   src/xdg_shell_stable.cpp
   src/main.cpp
   src/shared_library.cpp
+  src/xfail_supporting_test_listener.h
+  src/xfail_supporting_test_listener.cpp
 
   ${PROTOCOL_SOURCES}
 

--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -258,6 +258,12 @@ private:
     std::string const message;
 };
 
+class ExtensionExpectedlyNotSupported : public std::runtime_error
+{
+public:
+    ExtensionExpectedlyNotSupported(char const* extension, uint32_t version);
+};
+
 class InProcessServer : public testing::Test
 {
 public:

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -48,6 +48,17 @@ public:
     }
 };
 
+wlcs::ExtensionExpectedlyNotSupported::ExtensionExpectedlyNotSupported(char const* extension, uint32_t version)
+    : std::runtime_error{
+        std::string{"Extension: "} +
+        extension + " version " + std::to_string(version) +
+        " not supported by compositor under test."}
+{
+    auto const skip_reason =
+        std::string{"Missing extension: "} + extension + " v" + std::to_string(version);
+    ::testing::Test::RecordProperty("wlcs-skip-test", skip_reason);
+}
+
 class wlcs::Pointer::Impl
 {
 public:

--- a/src/termcolor.hpp
+++ b/src/termcolor.hpp
@@ -1,0 +1,557 @@
+//!
+//! termcolor
+//! ~~~~~~~~~
+//!
+//! termcolor is a header-only c++ library for printing colored messages
+//! to the terminal. Written just for fun with a help of the Force.
+//!
+//! :copyright: (c) 2013 by Ihor Kalnytskyi
+//! :license: BSD, see LICENSE for details
+//!
+
+#ifndef TERMCOLOR_HPP_
+#define TERMCOLOR_HPP_
+
+// the following snippet of code detects the current OS and
+// defines the appropriate macro that is used to wrap some
+// platform specific things
+#if defined(_WIN32) || defined(_WIN64)
+#   define TERMCOLOR_OS_WINDOWS
+#elif defined(__APPLE__)
+#   define TERMCOLOR_OS_MACOS
+#elif defined(__unix__) || defined(__unix)
+#   define TERMCOLOR_OS_LINUX
+#else
+#   error unsupported platform
+#endif
+
+
+// This headers provides the `isatty()`/`fileno()` functions,
+// which are used for testing whether a standart stream refers
+// to the terminal. As for Windows, we also need WinApi funcs
+// for changing colors attributes of the terminal.
+#if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+#   include <unistd.h>
+#elif defined(TERMCOLOR_OS_WINDOWS)
+#   include <io.h>
+#   include <windows.h>
+#endif
+
+
+#include <iostream>
+#include <cstdio>
+
+
+
+namespace termcolor
+{
+    // Forward declaration of the `_internal` namespace.
+    // All comments are below.
+    namespace _internal
+    {
+        // An index to be used to access a private storage of I/O streams. See
+        // colorize / nocolorize I/O manipulators for details.
+        static int colorize_index = std::ios_base::xalloc();
+
+        inline FILE* get_standard_stream(const std::ostream& stream);
+        inline bool is_colorized(std::ostream& stream);
+        inline bool is_atty(const std::ostream& stream);
+
+    #if defined(TERMCOLOR_OS_WINDOWS)
+        inline void win_change_attributes(std::ostream& stream, int foreground, int background=-1);
+    #endif
+    }
+
+    inline
+    std::ostream& colorize(std::ostream& stream)
+    {
+        stream.iword(_internal::colorize_index) = 1L;
+        return stream;
+    }
+
+    inline
+    std::ostream& nocolorize(std::ostream& stream)
+    {
+        stream.iword(_internal::colorize_index) = 0L;
+        return stream;
+    }
+
+    inline
+    std::ostream& reset(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[00m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1, -1);
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& bold(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[1m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& dark(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[2m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& underline(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[4m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& blink(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[5m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& reverse(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[7m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& concealed(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[8m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+        #endif
+        }
+        return stream;
+    }
+
+
+    inline
+    std::ostream& grey(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[30m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                0   // grey (black)
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& red(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[31m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& green(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[32m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_GREEN
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& yellow(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[33m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_GREEN | FOREGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& blue(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[34m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_BLUE
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& magenta(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[35m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_BLUE | FOREGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& cyan(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[36m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_BLUE | FOREGROUND_GREEN
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& white(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[37m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream,
+                FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+
+
+    inline
+    std::ostream& on_grey(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[40m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                0   // grey (black)
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_red(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[41m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_green(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[42m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_GREEN
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_yellow(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[43m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_GREEN | BACKGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_blue(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[44m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_BLUE
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_magenta(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[45m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_BLUE | BACKGROUND_RED
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_cyan(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[46m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_GREEN | BACKGROUND_BLUE
+            );
+        #endif
+        }
+        return stream;
+    }
+
+    inline
+    std::ostream& on_white(std::ostream& stream)
+    {
+        if (_internal::is_colorized(stream))
+        {
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            stream << "\033[47m";
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            _internal::win_change_attributes(stream, -1,
+                BACKGROUND_GREEN | BACKGROUND_BLUE | BACKGROUND_RED
+            );
+        #endif
+        }
+
+        return stream;
+    }
+
+
+
+    //! Since C++ hasn't a way to hide something in the header from
+    //! the outer access, I have to introduce this namespace which
+    //! is used for internal purpose and should't be access from
+    //! the user code.
+    namespace _internal
+    {
+        //! Since C++ hasn't a true way to extract stream handler
+        //! from the a given `std::ostream` object, I have to write
+        //! this kind of hack.
+        inline
+        FILE* get_standard_stream(const std::ostream& stream)
+        {
+            if (&stream == &std::cout)
+                return stdout;
+            else if ((&stream == &std::cerr) || (&stream == &std::clog))
+                return stderr;
+
+            return 0;
+        }
+
+        // Say whether a given stream should be colorized or not. It's always
+        // true for ATTY streams and may be true for streams marked with
+        // colorize flag.
+        inline
+        bool is_colorized(std::ostream& stream)
+        {
+            return is_atty(stream) || static_cast<bool>(stream.iword(colorize_index));
+        }
+
+        //! Test whether a given `std::ostream` object refers to
+        //! a terminal.
+        inline
+        bool is_atty(const std::ostream& stream)
+        {
+            FILE* std_stream = get_standard_stream(stream);
+
+            // Unfortunately, fileno() ends with segmentation fault
+            // if invalid file descriptor is passed. So we need to
+            // handle this case gracefully and assume it's not a tty
+            // if standard stream is not detected, and 0 is returned.
+            if (!std_stream)
+                return false;
+
+        #if defined(TERMCOLOR_OS_MACOS) || defined(TERMCOLOR_OS_LINUX)
+            return ::isatty(fileno(std_stream));
+        #elif defined(TERMCOLOR_OS_WINDOWS)
+            return ::_isatty(_fileno(std_stream));
+        #endif
+        }
+
+    #if defined(TERMCOLOR_OS_WINDOWS)
+        //! Change Windows Terminal colors attribute. If some
+        //! parameter is `-1` then attribute won't changed.
+        inline void win_change_attributes(std::ostream& stream, int foreground, int background)
+        {
+            // yeah, i know.. it's ugly, it's windows.
+            static WORD defaultAttributes = 0;
+
+            // Windows doesn't have ANSI escape sequences and so we use special
+            // API to change Terminal output color. That means we can't
+            // manipulate colors by means of "std::stringstream" and hence
+            // should do nothing in this case.
+            if (!_internal::is_atty(stream))
+                return;
+
+            // get terminal handle
+            HANDLE hTerminal = INVALID_HANDLE_VALUE;
+            if (&stream == &std::cout)
+                hTerminal = GetStdHandle(STD_OUTPUT_HANDLE);
+            else if (&stream == &std::cerr)
+                hTerminal = GetStdHandle(STD_ERROR_HANDLE);
+
+            // save default terminal attributes if it unsaved
+            if (!defaultAttributes)
+            {
+                CONSOLE_SCREEN_BUFFER_INFO info;
+                if (!GetConsoleScreenBufferInfo(hTerminal, &info))
+                    return;
+                defaultAttributes = info.wAttributes;
+            }
+
+            // restore all default settings
+            if (foreground == -1 && background == -1)
+            {
+                SetConsoleTextAttribute(hTerminal, defaultAttributes);
+                return;
+            }
+
+            // get current settings
+            CONSOLE_SCREEN_BUFFER_INFO info;
+            if (!GetConsoleScreenBufferInfo(hTerminal, &info))
+                return;
+
+            if (foreground != -1)
+            {
+                info.wAttributes &= ~(info.wAttributes & 0x0F);
+                info.wAttributes |= static_cast<WORD>(foreground);
+            }
+
+            if (background != -1)
+            {
+                info.wAttributes &= ~(info.wAttributes & 0xF0);
+                info.wAttributes |= static_cast<WORD>(background);
+            }
+
+            SetConsoleTextAttribute(hTerminal, info.wAttributes);
+        }
+    #endif // TERMCOLOR_OS_WINDOWS
+
+    } // namespace _internal
+
+} // namespace termcolor
+
+
+#undef TERMCOLOR_OS_WINDOWS
+#undef TERMCOLOR_OS_MACOS
+#undef TERMCOLOR_OS_LINUX
+
+#endif // TERMCOLOR_HPP_

--- a/src/xfail_supporting_test_listener.cpp
+++ b/src/xfail_supporting_test_listener.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#include "xfail_supporting_test_listener.h"
+#include <gtest/gtest.h>
+#include <chrono>
+
+namespace testing
+{
+namespace internal
+{
+enum class GTestColor
+{
+    Default, Red, Green, Yellow
+};
+extern void ColoredPrintf(GTestColor color, const char* fmt, ...);
+}
+}
+
+testing::XFailSupportingTestListenerWrapper::XFailSupportingTestListenerWrapper(std::unique_ptr<testing::TestEventListener>&& wrapped)
+        : delegate{std::move(wrapped)}
+{
+}
+
+void testing::XFailSupportingTestListenerWrapper::OnTestProgramStart(testing::UnitTest const& unit_test)
+{
+    delegate->OnTestProgramStart(unit_test);
+}
+
+void testing::XFailSupportingTestListenerWrapper::OnTestIterationStart(testing::UnitTest const& unit_test, int iteration)
+{
+    delegate->OnTestIterationStart(unit_test, iteration);
+}
+
+void testing::XFailSupportingTestListenerWrapper::OnEnvironmentsSetUpStart(testing::UnitTest const& unit_test)
+{
+    delegate->OnEnvironmentsSetUpStart(unit_test);
+}
+
+void testing::XFailSupportingTestListenerWrapper::OnEnvironmentsSetUpEnd(testing::UnitTest const& unit_test)
+{
+    delegate->OnEnvironmentsSetUpEnd(unit_test);
+}
+
+void testing::XFailSupportingTestListenerWrapper::OnTestCaseStart(testing::TestCase const& test_case)
+{
+    delegate->OnTestCaseStart(test_case);
+}
+
+void testing::XFailSupportingTestListenerWrapper::OnTestStart(testing::TestInfo const& test_info)
+{
+    current_test_info = &test_info;
+    current_test_start = std::chrono::steady_clock::now();
+    delegate->OnTestStart(test_info);
+}
+
+void testing::XFailSupportingTestListenerWrapper::OnTestPartResult(testing::TestPartResult const& test_part_result)
+{
+    if (test_part_result.failed())
+    {
+        // Search for expected-failure property
+        for (int i= 0; i < current_test_info->result()->test_property_count() ; ++i)
+        {
+            auto prop = current_test_info->result()->GetTestProperty(i);
+            if (strcmp(prop.key(), "wlcs-skip-test") == 0)
+            {
+                if (!current_skip_reasons)
+                {
+                    current_skip_reasons = std::vector<std::string>{};
+                }
+                current_skip_reasons->push_back(prop.value());
+            }
+        }
+        if (current_skip_reasons)
+        {
+            skipped_test_names.insert(std::string{current_test_info->test_case_name()} + "." + current_test_info->name());
+            return;
+        }
+
+        failed_test_names.insert(std::string{current_test_info->test_case_name()} + "." + current_test_info->name());
+    }
+    delegate->OnTestPartResult(test_part_result);
+}
+
+void testing::XFailSupportingTestListenerWrapper::OnTestEnd(testing::TestInfo const& test_info)
+{
+    using namespace testing::internal;
+    if (current_skip_reasons)
+    {
+        for (auto const& reason : *current_skip_reasons)
+        {
+            ColoredPrintf(GTestColor::Yellow, "[          ]");
+            ColoredPrintf(GTestColor::Default, " %s\n", reason.c_str());
+        }
+        auto elapsed_time = std::chrono::steady_clock::now() - current_test_start;
+
+        ColoredPrintf(GTestColor::Yellow, "[     SKIP ]");
+        ColoredPrintf(
+            GTestColor::Default, " %s.%s (%ld ms)\n",
+            test_info.test_case_name(),
+            test_info.name(),
+            std::chrono::duration_cast<std::chrono::milliseconds>(elapsed_time).count());
+    }
+    else
+    {
+        delegate->OnTestEnd(test_info);
+    }
+    current_skip_reasons = {};
+}
+
+void testing::XFailSupportingTestListenerWrapper::OnTestCaseEnd(testing::TestCase const& test_case)
+{
+    delegate->OnTestCaseEnd(test_case);
+}
+
+void testing::XFailSupportingTestListenerWrapper::OnEnvironmentsTearDownStart(testing::UnitTest const& unit_test)
+{
+    delegate->OnEnvironmentsTearDownStart(unit_test);
+}
+
+void testing::XFailSupportingTestListenerWrapper::OnEnvironmentsTearDownEnd(testing::UnitTest const& unit_test)
+{
+    delegate->OnEnvironmentsTearDownEnd(unit_test);
+}
+
+void testing::XFailSupportingTestListenerWrapper::OnTestIterationEnd(testing::UnitTest const& unit_test, int /*iteration*/)
+{
+    using namespace testing::internal;
+    ColoredPrintf(GTestColor::Green, "[==========] ");
+
+    ColoredPrintf(
+        GTestColor::Default, "%i tests from %i test cases run. (%ims total elapsed)\n",
+        unit_test.test_to_run_count(),
+        unit_test.test_case_to_run_count(),
+        unit_test.elapsed_time());
+    ColoredPrintf(GTestColor::Green, "[  PASSED  ]");
+    ColoredPrintf(GTestColor::Default,
+        " %i test%s\n",
+        unit_test.successful_test_count(),
+        unit_test.successful_test_count() == 1 ? "" : "s");
+    if (skipped_test_names.size() > 0)
+    {
+        ColoredPrintf(GTestColor::Yellow, "[  SKIPPED ]");
+        ColoredPrintf(GTestColor::Default,
+                      " %i test%s skipped:\n",
+                      skipped_test_names.size(),
+                      skipped_test_names.size() == 1 ? "" : "s");
+        for (auto const name : skipped_test_names)
+        {
+            ColoredPrintf(GTestColor::Yellow, "[  SKIPPED ]");
+            ColoredPrintf(GTestColor::Default, " %s\n", name.c_str());
+        }
+    }
+    if (failed_test_names.size() > 0)
+    {
+        ColoredPrintf(GTestColor::Red, "[  FAILED  ]");
+        ColoredPrintf(GTestColor::Default,
+                      " %i test%s failed:\n",
+                      failed_test_names.size(),
+                      failed_test_names.size() == 1 ? "" : "s");
+        for (auto const name : failed_test_names)
+        {
+            ColoredPrintf(GTestColor::Red, "[  FAILED  ]");
+            ColoredPrintf(GTestColor::Default, " %s\n", name.c_str());
+        }
+    }
+}
+
+void testing::XFailSupportingTestListenerWrapper::OnTestProgramEnd(testing::UnitTest const& unit_test)
+{
+    delegate->OnTestProgramEnd(unit_test);
+}
+
+bool testing::XFailSupportingTestListenerWrapper::failed() const
+{
+    return failed_;
+}

--- a/src/xfail_supporting_test_listener.h
+++ b/src/xfail_supporting_test_listener.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#ifndef WLCS_XFAIL_SUPPORTING_TEST_LISTENER_H_
+#define WLCS_XFAIL_SUPPORTING_TEST_LISTENER_H_
+
+#include <gtest/gtest.h>
+
+#include <experimental/optional>
+#include <vector>
+#include <string>
+#include <chrono>
+#include <unordered_set>
+
+namespace testing
+{
+class XFailSupportingTestListenerWrapper : public testing::TestEventListener
+{
+public:
+    explicit XFailSupportingTestListenerWrapper(std::unique_ptr<testing::TestEventListener>&& wrapped);
+
+    void OnTestProgramStart(testing::UnitTest const& unit_test) override;
+
+    void OnTestIterationStart(testing::UnitTest const& unit_test, int iteration) override;
+
+    void OnEnvironmentsSetUpStart(testing::UnitTest const& unit_test) override;
+
+    void OnEnvironmentsSetUpEnd(testing::UnitTest const& unit_test) override;
+
+    void OnTestCaseStart(testing::TestCase const& test_case) override;
+
+    void OnTestStart(testing::TestInfo const& test_info) override;
+
+    void OnTestPartResult(testing::TestPartResult const& test_part_result) override;
+
+    void OnTestEnd(testing::TestInfo const& test_info) override;
+    void OnTestCaseEnd(testing::TestCase const& test_case) override;
+
+    void OnEnvironmentsTearDownStart(testing::UnitTest const& unit_test) override;
+
+    void OnEnvironmentsTearDownEnd(testing::UnitTest const& unit_test) override;
+
+    void OnTestIterationEnd(testing::UnitTest const& unit_test, int iteration) override;
+
+    void OnTestProgramEnd(testing::UnitTest const& unit_test) override;
+
+    bool failed() const;
+private:
+    std::unique_ptr<testing::TestEventListener> const delegate;
+
+    std::chrono::steady_clock::time_point current_test_start;
+    ::testing::TestInfo const* current_test_info;
+    std::experimental::optional<std::vector<std::string>> current_skip_reasons;
+
+    std::unordered_set<std::string> failed_test_names;
+    std::unordered_set<std::string> skipped_test_names;
+
+    bool failed_{false};
+};
+
+}
+
+#endif //WLCS_XFAIL_SUPPORTING_TEST_LISTENER_H_

--- a/tests/self_test.cpp
+++ b/tests/self_test.cpp
@@ -100,3 +100,10 @@ TEST_F(SelfTest, given_second_client_when_both_create_a_surface_nothing_bad_happ
         client2.roundtrip();
     }
 }
+
+TEST_F(SelfTest, xfail_failure_is_noted)
+{
+    ::testing::Test::RecordProperty("wlcs-skip-test", "Reason goes here");
+
+    FAIL() << "This message shouldn't be seen";
+}

--- a/tests/self_test.cpp
+++ b/tests/self_test.cpp
@@ -107,3 +107,8 @@ TEST_F(SelfTest, xfail_failure_is_noted)
 
     FAIL() << "This message shouldn't be seen";
 }
+
+TEST_F(SelfTest, expected_missing_extension_is_xfail)
+{
+    throw wlcs::ExtensionExpectedlyNotSupported("xdg_not_really_an_extension", 1);
+}


### PR DESCRIPTION
These are handled by using GTest's annotation support. A test which is
expected to fail marks itself with the "wlcs-skip-test" attribute, with
an optional skip reason, and the test listener picks up that attribute
and does not record the test it came from as a failure.