### PR TITLE
Skip tests of known-unsupported protocols.

### DIFF
--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -27,6 +27,7 @@
 
 #include <memory>
 #include <functional>
+#include <unordered_map>
 #include "shared_library.h"
 
 #include <wayland-client.h>
@@ -101,6 +102,8 @@ public:
 
     void start();
     void stop();
+
+    std::shared_ptr<std::unordered_map<char const*, uint32_t> const> supported_extensions();
 private:
     class Impl;
     std::unique_ptr<Impl> const impl;

--- a/include/wlcs/display_server.h
+++ b/include/wlcs/display_server.h
@@ -30,8 +30,22 @@ typedef struct wl_display wl_display;
 typedef struct WlcsPointer WlcsPointer;
 typedef struct WlcsTouch WlcsTouch;
 
-#define WLCS_DISPLAY_SERVER_VERSION 1
+#define WLCS_INTEGRATION_DESCRIPTOR_VERSION 1
+struct WlcsExtensionDescriptor
+{
+    char const* name;
+    uint32_t version;
+};
 
+struct WlcsIntegrationDescriptor
+{
+    uint32_t version;
+
+    size_t num_extensions;
+    WlcsExtensionDescriptor const* supported_extensions;
+};
+
+#define WLCS_DISPLAY_SERVER_VERSION 2
 struct WlcsDisplayServer
 {
     uint32_t version;
@@ -45,10 +59,12 @@ struct WlcsDisplayServer
 
     WlcsPointer* (*create_pointer)(WlcsDisplayServer* server);
     WlcsTouch* (*create_touch)(WlcsDisplayServer* server);
+
+    /* Added in version 2 */
+    WlcsIntegrationDescriptor const* (*get_descriptor)();
 };
 
 #define WLCS_SERVER_INTEGRATION_VERSION 1
-
 struct WlcsServerIntegration
 {
     uint32_t version;

--- a/tests/self_test.cpp
+++ b/tests/self_test.cpp
@@ -112,3 +112,41 @@ TEST_F(SelfTest, expected_missing_extension_is_xfail)
 {
     throw wlcs::ExtensionExpectedlyNotSupported("xdg_not_really_an_extension", 1);
 }
+
+TEST_F(SelfTest, acquiring_unsupported_extension_is_xfail)
+{
+    auto const extension_list = the_server().supported_extensions();
+
+    if (!extension_list)
+    {
+        ::testing::Test::RecordProperty("wlcs-skip-test", "Compositor Integration module is too old for expected extension failures");
+        FAIL() << "Requires unsupported feature from module under test";
+    }
+
+    auto unsupported_extension =
+        std::string{"wlcs_non_existent_extension"} + extension_list->begin()->first;
+
+    Client client{the_server()};
+
+    client.acquire_interface(unsupported_extension, &wl_buffer_interface, 1);
+
+    FAIL() << "We should have (x)failed at acquiring the interface";
+}
+
+TEST_F(SelfTest, acquiring_unsupported_extension_version_is_xfail)
+{
+    auto const extension_list = the_server().supported_extensions();
+
+    if (!extension_list)
+    {
+        ::testing::Test::RecordProperty("wlcs-skip-test", "Compositor Integration module is too old for expected extension failures");
+        FAIL() << "Requires unsupported feature from module under test";
+    }
+
+    auto const unsupported_extension_version = extension_list->begin()->second + 1;
+    Client client{the_server()};
+
+    client.acquire_interface(extension_list->begin()->first, &wl_buffer_interface, unsupported_extension_version);
+
+    FAIL() << "We should have (x)failed at acquiring the interface";
+}


### PR DESCRIPTION
This relies on tests using the `Client::acquire_interface()` method, but tests that do
will automatically be skipped if the compositor integration module indicates that
the extension, or version of the extension, is not available.