### PR TITLE
Fix program return code

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,8 +85,13 @@ int main(int argc, char** argv)
             listeners.Release(listeners.default_result_printer())}};
     listeners.Append(wrapping_listener);
 
-    auto result = RUN_ALL_TESTS();
-    if (result || wrapping_listener->failed())
+    /* (void)! is apparently the magical incantation required to get GCC to
+     * *actually* silently ignore the return value of a function declared with
+     * __attribute__(("warn_unused_result"))
+     * cf: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66425
+     */
+    (void)!RUN_ALL_TESTS();
+    if (wrapping_listener->failed())
     {
         return EXIT_FAILURE;
     }

--- a/src/xfail_supporting_test_listener.cpp
+++ b/src/xfail_supporting_test_listener.cpp
@@ -33,6 +33,8 @@ void testing::XFailSupportingTestListenerWrapper::OnTestProgramStart(testing::Un
 
 void testing::XFailSupportingTestListenerWrapper::OnTestIterationStart(testing::UnitTest const& unit_test, int iteration)
 {
+    failed_test_names.clear();
+    skipped_test_names.clear();
     delegate->OnTestIterationStart(unit_test, iteration);
 }
 

--- a/src/xfail_supporting_test_listener.cpp
+++ b/src/xfail_supporting_test_listener.cpp
@@ -178,6 +178,12 @@ void testing::XFailSupportingTestListenerWrapper::OnTestIterationEnd(testing::Un
     auto const failed_tests = failed_test_names.size();
     if (failed_tests > 0)
     {
+        /* Mark the test run as a failure; if multiple iterations are run
+         * only one might fail, making failed_test_names() an unreliable
+         * indicator.
+         */
+        failed_ = true;
+
         std::cout
             << termcolor::red << "[  FAILED  ] "
             << termcolor::reset


### PR DESCRIPTION
Because `RUN_ALL_TESTS()` doesn't understand skipped tests, `wlcs` would return `EXIT_FAILURE` if a test was skipped. This is not what we want, particularly since we have skipped tests as a part of the `SelfTest` suite.