### PR TITLE
Fix signature of WlcsDisplayServer::get_descriptor

### DIFF
--- a/include/wlcs/display_server.h
+++ b/include/wlcs/display_server.h
@@ -65,7 +65,7 @@ struct WlcsDisplayServer
     WlcsTouch* (*create_touch)(WlcsDisplayServer* server);
 
     /* Added in version 2 */
-    WlcsIntegrationDescriptor const* (*get_descriptor)();
+    WlcsIntegrationDescriptor const* (*get_descriptor)(WlcsDisplayServer const* server);
 };
 
 #define WLCS_SERVER_INTEGRATION_VERSION 1

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -219,7 +219,7 @@ std::shared_ptr<std::unordered_map<char const*, uint32_t> const> extract_support
         return {};
     }
 
-    auto const descriptor = server->get_descriptor();
+    auto const descriptor = server->get_descriptor(server);
     auto extensions = std::make_shared<std::unordered_map<char const*, uint32_t>>();
 
     for (auto i = 0u; i < descriptor->num_extensions; ++i)


### PR DESCRIPTION
It's entirely possible that the set of extensions a compositor supports
might be different with different invokations (eg: Mir's default_extensions).
We shouldn't require the set of extensions to be fixed at compositor-integration
time, but allow them to be WlcsDisplayServer-specific.