### PR TITLE
Document (and then fix) our various WLCS_$INTERFACE_VERSION macros

### DIFF
--- a/include/wlcs/display_server.h
+++ b/include/wlcs/display_server.h
@@ -62,7 +62,7 @@ struct WlcsIntegrationDescriptor
     WlcsExtensionDescriptor const* supported_extensions;
 };
 
-#define WLCS_DISPLAY_SERVER_VERSION 2
+#define WLCS_DISPLAY_SERVER_VERSION 3
 typedef struct WlcsDisplayServer WlcsDisplayServer;
 struct WlcsDisplayServer
 {

--- a/include/wlcs/display_server.h
+++ b/include/wlcs/display_server.h
@@ -32,6 +32,9 @@ typedef struct wl_event_loop wl_event_loop;
 typedef struct WlcsPointer WlcsPointer;
 typedef struct WlcsTouch WlcsTouch;
 
+/**
+ * Maximum version of WlcsIntegrationDescriptor this header provides a definition for
+ */
 #define WLCS_INTEGRATION_DESCRIPTOR_VERSION 1
 typedef struct WlcsExtensionDescriptor WlcsExtensionDescriptor;
 struct WlcsExtensionDescriptor
@@ -62,6 +65,9 @@ struct WlcsIntegrationDescriptor
     WlcsExtensionDescriptor const* supported_extensions;
 };
 
+/**
+ * Maximum version of WlcsDisplayServer this header provides a definition for
+ */
 #define WLCS_DISPLAY_SERVER_VERSION 3
 typedef struct WlcsDisplayServer WlcsDisplayServer;
 struct WlcsDisplayServer
@@ -152,6 +158,9 @@ struct WlcsDisplayServer
     void (*start_on_this_thread)(WlcsDisplayServer* server, wl_event_loop* wlcs_event_dispatcher);
 };
 
+/**
+ * Maximum version of WlcsServerIntegration this header provides a definition of
+ */
 #define WLCS_SERVER_INTEGRATION_VERSION 1
 typedef struct WlcsServerIntegration WlcsServerIntegration;
 struct WlcsServerIntegration

--- a/include/wlcs/pointer.h
+++ b/include/wlcs/pointer.h
@@ -24,6 +24,9 @@
 extern "C" {
 #endif
 
+/**
+ * Maximum version of WlcsPointer this header provides a definition for
+ */
 #define WLCS_POINTER_VERSION 1
 
 typedef struct WlcsPointer WlcsPointer;

--- a/include/wlcs/touch.h
+++ b/include/wlcs/touch.h
@@ -24,6 +24,9 @@
 extern "C" {
 #endif
 
+/**
+ * Maximum version of WlcsTouch this header provides a definition for
+ */
 #define WLCS_TOUCH_VERSION 1
 
 typedef struct WlcsTouch WlcsTouch;


### PR DESCRIPTION
These are intended to tell compositor test-fixture code the maximum version
of the various interface structs the header provides.

Document them as doing just that.

And then fix the `WLCS_DISPLAY_SERVER_VERSION` one, as that was 2 but we've got version 3 calls documented in the struct.