### PR TITLE
Fix supported_extensions()

### DIFF
--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -113,7 +113,7 @@ public:
     void start();
     void stop();
 
-    std::shared_ptr<std::unordered_map<char const*, uint32_t> const> supported_extensions();
+    std::shared_ptr<const std::unordered_map<std::string, uint32_t>> supported_extensions();
 private:
     class Impl;
     std::unique_ptr<Impl> const impl;
@@ -315,6 +315,13 @@ public:
 
     void SetUp() override {}
     void TearDown() override {}
+};
+
+// Check the server expects to support an interface
+class CheckInterfaceExpected : private Client
+{
+public:
+    CheckInterfaceExpected(Server& server, wl_interface const& interface);
 };
 
 }

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -292,7 +292,7 @@ void wlcs::Touch::up()
 
 namespace
 {
-std::shared_ptr<std::unordered_map<char const*, uint32_t> const> extract_supported_extensions(WlcsDisplayServer* server)
+std::shared_ptr<std::unordered_map<std::string, uint32_t> const> extract_supported_extensions(WlcsDisplayServer* server)
 {
     if (server->version < 2)
     {
@@ -300,7 +300,7 @@ std::shared_ptr<std::unordered_map<char const*, uint32_t> const> extract_support
     }
 
     auto const descriptor = server->get_descriptor(server);
-    auto extensions = std::make_shared<std::unordered_map<char const*, uint32_t>>();
+    auto extensions = std::make_shared<std::unordered_map<std::string, uint32_t>>();
 
     for (auto i = 0u; i < descriptor->num_extensions; ++i)
     {
@@ -422,7 +422,7 @@ public:
         return server.get();
     }
 
-    std::shared_ptr<std::unordered_map<char const*, uint32_t> const> supported_extensions() const
+    std::shared_ptr<const std::unordered_map<std::string, uint32_t>> supported_extensions() const
     {
         return supported_extensions_;
     }
@@ -480,7 +480,7 @@ private:
     std::unique_ptr<WlcsDisplayServer, void(*)(WlcsDisplayServer*)> const server;
     std::experimental::optional<ThreadContext> thread_context;
     std::shared_ptr<WlcsServerIntegration const> const hooks;
-    std::shared_ptr<std::unordered_map<char const*, uint32_t> const> const supported_extensions_;
+    std::shared_ptr<std::unordered_map<std::string, uint32_t> const> const supported_extensions_;
 
     template<typename Proxy>
     void initialise_thunks(std::shared_ptr<Proxy> proxy)
@@ -547,7 +547,7 @@ void wlcs::Server::stop()
     impl->stop();
 }
 
-std::shared_ptr<std::unordered_map<char const*, uint32_t> const> wlcs::Server::supported_extensions()
+std::shared_ptr<const std::unordered_map<std::string, uint32_t>> wlcs::Server::supported_extensions()
 {
     return impl->supported_extensions();
 }
@@ -1283,7 +1283,7 @@ private:
         &global_removed
     };
 
-    std::shared_ptr<std::unordered_map<char const*, uint32_t> const> const supported_extensions;
+    std::shared_ptr<std::unordered_map<std::string, uint32_t> const> const supported_extensions;
 
     struct wl_display* display;
     struct wl_registry* registry = nullptr;
@@ -1738,4 +1738,9 @@ wlcs::ShmBuffer::operator wl_buffer*() const
 void wlcs::ShmBuffer::add_release_listener(std::function<bool()> const &on_release)
 {
     impl->add_release_listener(on_release);
+}
+
+wlcs::CheckInterfaceExpected::CheckInterfaceExpected(Server& server, wl_interface const& interface) : Client{server}
+{
+    acquire_interface(interface.name, &interface, interface.version);
 }

--- a/tests/primary_selection.cpp
+++ b/tests/primary_selection.cpp
@@ -60,27 +60,9 @@ struct SinkApp : Client
     PrimarySelectionDevice device{primary_selection_device_manager(), seat()};
 };
 
-struct PrimarySelectionCheck
-{
-    explicit PrimarySelectionCheck(Server& server)
-    {
-        bool supported = false;
-
-        // Do we really have to iterate over the keys and compare strings? Issue #107
-        for (auto& extension : *server.supported_extensions())
-        {
-            if (strcmp("zwp_primary_selection_device_manager_v1", extension.first) == 0)
-                supported = true;
-        }
-
-        if (!supported)
-            throw ExtensionExpectedlyNotSupported("zwp_primary_selection_device_manager_v1", 1);
-    }
-};
-
 struct PrimarySelection : StartedInProcessServer
 {
-    PrimarySelectionCheck must_be_first{the_server()};
+    CheckInterfaceExpected must_be_first{the_server(), zwp_primary_selection_device_manager_v1_interface};
     SourceApp   source_app{the_server()};
     SinkApp     sink_app{the_server()};
 


### PR DESCRIPTION
Fix supported_extensions(). (Fixes #107)

Also adds (and uses) a utility class to simplify the syntax for checking an extension is supported.