### PR TITLE
dispatch_until(): Timeout rather than waiting indefinitely.

### DIFF
--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -30,6 +30,8 @@
 #include <functional>
 #include <experimental/optional>
 #include <unordered_map>
+#include <chrono>
+
 #include "shared_library.h"
 
 #include <wayland-client.h>
@@ -243,7 +245,10 @@ public:
 
     void* acquire_interface(std::string const& name, wl_interface const* interface, uint32_t version);
 
-    void dispatch_until(std::function<bool()> const& predicate);
+    void dispatch_until(
+        std::function<bool()> const& predicate,
+        std::chrono::seconds timeout = std::chrono::seconds{10});
+
     void roundtrip();
 private:
     class Impl;

--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -294,6 +294,12 @@ public:
     ExtensionExpectedlyNotSupported(char const* extension, uint32_t version);
 };
 
+class Timeout : public std::runtime_error
+{
+public:
+    explicit Timeout(char const* message);
+};
+
 class InProcessServer : public testing::Test
 {
 public:

--- a/tests/self_test.cpp
+++ b/tests/self_test.cpp
@@ -150,3 +150,23 @@ TEST_F(SelfTest, acquiring_unsupported_extension_version_is_xfail)
 
     FAIL() << "We should have (x)failed at acquiring the interface";
 }
+
+TEST_F(SelfTest, dispatch_until_times_out_on_failure)
+{
+    Client client{the_server()};
+
+    // Ensure that there's some events happening on the Wayland socket
+    auto dummy = client.create_visible_surface(300, 300);
+    dummy.attach_buffer(300, 300);
+    wl_surface_commit(dummy);
+
+    try
+    {
+        client.dispatch_until([]() { return false; });
+    }
+    catch (wlcs::Timeout const&)
+    {
+        return;
+    }
+    FAIL() << "Dispatch did not raise a wlcs::Timeout exception";
+}

--- a/tests/self_test.cpp
+++ b/tests/self_test.cpp
@@ -173,9 +173,11 @@ TEST_F(SelfTest, dispatch_until_times_out_on_failure)
 
 TEST_F(SelfTest, dispatch_until_times_out_at_the_right_time)
 {
+    using namespace std::literals::chrono_literals;
+
     Client client{the_server()};
 
-    auto const timeout = std::chrono::seconds{10};
+    auto const timeout = 5s;
     auto const expected_end = std::chrono::steady_clock::now() + timeout;
     try
     {
@@ -183,10 +185,8 @@ TEST_F(SelfTest, dispatch_until_times_out_at_the_right_time)
     }
     catch (wlcs::Timeout const&)
     {
-        auto const skew = std::chrono::steady_clock::now() - expected_end;
-        EXPECT_THAT(
-            abs(std::chrono::duration_cast<std::chrono::seconds>(skew).count()),
-            Le(5) );
+        EXPECT_THAT(std::chrono::steady_clock::now(), Gt(expected_end));
+        EXPECT_THAT(std::chrono::steady_clock::now(), Lt(expected_end + 5s));
         return;
     }
     FAIL() << "Dispatch did not raise a wlcs::Timeout exception";


### PR DESCRIPTION
Do the (surprisingly involved) dance required to `poll` the wayland fd so that we can wait for a specified time, rather than forever.

Fixes: #89 