### PR TITLE
pkgconfig: Actually point to the correct runner binary

### DIFF
--- a/wlcs.pc.in
+++ b/wlcs.pc.in
@@ -1,9 +1,9 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}/@CMAKE_INSTALL_BINDIR@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+libexecdir=${prefix}/@CMAKE_INSTALL_LIBEXECDIR@
 includedir=${prefix}/include
 
-test_runner=${libdir}/wlcs/wlcs
+test_runner=${libexecdir}/wlcs/wlcs
 
 Name: wlcs
 Description: Wayland Conformance Suite test harness


### PR DESCRIPTION
In 20515298c66595629703e628424cca0c81eb72e0, the install path was changed, but the pkgconfig file wasn't fixed alongside it.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>