### PR TITLE
Drop 18.10 from PPA uploads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,8 +78,6 @@ jobs:
   - <<: *ppa-upload
     env: RELEASE=18.04
   - <<: *ppa-upload
-    env: RELEASE=18.10
-  - <<: *ppa-upload
     env: RELEASE=19.04
   - <<: *ppa-upload
     env: RELEASE=devel


### PR DESCRIPTION
Drop 18.10 from PPA uploads.

It is out of support