### PR TITLE
Fix Client::dispatch_until() timing out early

### DIFF
--- a/include/gtest_helpers.h
+++ b/include/gtest_helpers.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2019 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: Christopher James Halse Rogers <christopher.halse.rogers@canonical.com>
+ */
+
+#include <chrono>
+#include <ostream>
+#include <iomanip>
+
+namespace std
+{
+namespace chrono
+{
+/// GTest helper to pretty-print time-points
+template<typename Clock>
+void PrintTo(time_point<Clock> const& time, ostream* os)
+{
+    auto remainder = time.time_since_epoch();
+    auto const hours = duration_cast<chrono::hours>(remainder);
+    remainder -= hours;
+    auto const minutes = duration_cast<chrono::minutes>(remainder);
+    remainder -= minutes;
+    auto const seconds = duration_cast<chrono::seconds>(remainder);
+    remainder -= seconds;
+    auto const nsec = duration_cast<chrono::nanoseconds>(remainder);
+    (*os)
+        << hours.count()
+        << ":" << setw(2) << setfill('0') << minutes.count()
+        << ":" << setw(2) << setfill('0') << seconds.count()
+        << "." << setw(9) << setfill('0') << nsec.count();
+}
+}
+}

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -920,7 +920,9 @@ public:
     void dispatch_until(
         std::function<bool()> const& predicate, std::chrono::seconds timeout)
     {
-        auto const end_time = std::chrono::steady_clock::now() + timeout;
+        using namespace std::chrono;
+
+        auto const end_time = steady_clock::now() + timeout;
         while (!predicate())
         {
             while (wl_display_prepare_read(display) != 0)
@@ -930,7 +932,7 @@ public:
             }
             wl_display_flush(display);
 
-            auto const time_left = end_time - std::chrono::steady_clock::now();
+            auto const time_left = end_time - steady_clock::now();
             if (time_left.count() < 0)
             {
                 BOOST_THROW_EXCEPTION((Timeout{"Timeout waiting for condition"}));
@@ -945,9 +947,7 @@ public:
              *
              * Adding 1ms will ensure we wait until *after* we're meant to timeout.
              */
-            auto const maximum_wait_ms =
-                std::chrono::duration_cast<std::chrono::milliseconds>(time_left) +
-                    std::chrono::milliseconds{1};
+            auto const maximum_wait_ms = duration_cast<milliseconds>(time_left) + 1ms;
             pollfd fd{
                 wl_display_get_fd(display),
                 POLLIN | POLLERR,

--- a/tests/self_test.cpp
+++ b/tests/self_test.cpp
@@ -18,6 +18,7 @@
 
 #include "data_device.h"
 #include "helpers.h"
+#include "gtest_helpers.h"
 #include "in_process_server.h"
 
 #include <gmock/gmock.h>


### PR DESCRIPTION
Because `duration_cast<milliseconds>(maximum_wait)` performs integer division we lose any fractional milliseconds in `maximum_wait`, meaning that `poll()` could return up to 1ms before we were intending to timeout.