### PR TITLE
Remove extra implementations of StartedInProcessServer

### DIFF
--- a/tests/frame_submission.cpp
+++ b/tests/frame_submission.cpp
@@ -26,11 +26,6 @@ using namespace wlcs;
 
 namespace
 {
-struct StartedInProcessServer : InProcessServer
-{
-    StartedInProcessServer() { InProcessServer::SetUp(); }
-    void SetUp() override {}
-};
 
 struct FrameSubmission : StartedInProcessServer
 {

--- a/tests/self_test.cpp
+++ b/tests/self_test.cpp
@@ -29,12 +29,6 @@ using namespace wlcs;
 
 namespace
 {
-struct StartedInProcessServer : InProcessServer
-{
-    StartedInProcessServer() { InProcessServer::SetUp(); }
-
-    void SetUp() override {}
-};
 
 struct SelfTest : StartedInProcessServer
 {


### PR DESCRIPTION
These classes are both redundant and incorrect. The better implementation in `in_process_server.h` which these hide calls `InProcessServer::TearDown()` in the destructor. Not doing this was, for some reason, causing some Wayland connections to not close (as observed by wayland-debug)