### PR TITLE
Improve touch and pointer tests

### DIFF
--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -236,6 +236,7 @@ public:
     std::pair<wl_fixed_t, wl_fixed_t> pointer_position() const;
     std::pair<wl_fixed_t, wl_fixed_t> touch_position() const;
     bool pointer_events_clean() const; ///< If we have gotten a frame event since the last pointer event
+    bool touch_events_clean() const; ///< If we have gotten a frame event since the last touch event
 
     using PointerEnterNotifier =
         std::function<bool(wl_surface*, wl_fixed_t x, wl_fixed_t y)>;

--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -235,6 +235,7 @@ public:
     wl_surface* touched_window() const;
     std::pair<wl_fixed_t, wl_fixed_t> pointer_position() const;
     std::pair<wl_fixed_t, wl_fixed_t> touch_position() const;
+    bool pointer_events_clean() const; ///< If we have gotten a frame event since the last pointer event
 
     using PointerEnterNotifier =
         std::function<bool(wl_surface*, wl_fixed_t x, wl_fixed_t y)>;

--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -235,8 +235,6 @@ public:
     wl_surface* touched_window() const;
     std::pair<wl_fixed_t, wl_fixed_t> pointer_position() const;
     std::pair<wl_fixed_t, wl_fixed_t> touch_position() const;
-    bool pointer_events_clean() const; ///< If we have gotten a frame event since the last pointer event
-    bool touch_events_clean() const; ///< If we have gotten a frame event since the last touch event
 
     using PointerEnterNotifier =
         std::function<bool(wl_surface*, wl_fixed_t x, wl_fixed_t y)>;

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -1104,18 +1104,18 @@ private:
         void* ctx,
         wl_pointer* /*pointer*/,
         uint32_t /*serial*/,
-        wl_surface* /*surface*/)
+        wl_surface* surface)
     {
         auto me = static_cast<Impl*>(ctx);
 
         if (!me->current_pointer_location)
             FAIL() << "Got wl_pointer.leave when the pointer was not on a surface";
 
-//         TODO: uncomment this and fix the issue it exposes in Mir (Mir is seding null surfaces)
-//         if (me->current_pointer_location.value().surface != surface)
-//             FAIL()
-//                 << "Got wl_pointer.leave with surface " << surface
-//                 << " instead of " << me->current_pointer_location.value().surface;
+        // the surface should never be null along the wire, but may come out as null if it's been destroyed
+        if (surface != nullptr && surface != me->current_pointer_location.value().surface)
+            FAIL()
+                << "Got wl_pointer.leave with surface " << surface
+                << " instead of " << me->current_pointer_location.value().surface;
 
         me->pending_pointer_location = std::experimental::nullopt;
         me->pending_pointer_leave = true;

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -829,7 +829,7 @@ public:
         for (auto const& touch : current_touches)
         {
             if (surface && touch.second.surface != surface)
-                BOOST_THROW_EXCEPTION(std::logic_error("touched_window() when multiple surfaces have active touches"));
+                BOOST_THROW_EXCEPTION(std::runtime_error("Multiple surfaces have active touches"));
             else
                 surface = touch.second.surface;
         }
@@ -844,11 +844,11 @@ public:
     std::pair<wl_fixed_t, wl_fixed_t> touch_position() const
     {
         if (current_touches.empty())
-            BOOST_THROW_EXCEPTION(std::logic_error("touch_position() when there are no touches"));
+            BOOST_THROW_EXCEPTION(std::runtime_error("No touches"));
         else if (current_touches.size() == 1)
             return current_touches.begin()->second.coordinates;
         else
-            BOOST_THROW_EXCEPTION(std::logic_error("touch_position() when there are more than 1 touches"));
+            BOOST_THROW_EXCEPTION(std::runtime_error("More than one touches"));
     };
 
     void add_pointer_enter_notification(PointerEnterNotifier const& on_enter)

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -1090,8 +1090,9 @@ private:
         auto me = static_cast<Impl*>(ctx);
 
         if (me->current_pointer_location && !me->pending_pointer_leave)
-            BOOST_THROW_EXCEPTION(std::logic_error(
-                "Pointer tried to enter a surface without first leaving the previous one"));
+            FAIL()
+                << "Pointer tried to enter surface " << surface
+                << " without first leaving surface " << me->current_pointer_location.value().surface;
 
         me->pending_pointer_location = SurfaceLocation{
             surface,
@@ -1108,13 +1109,13 @@ private:
         auto me = static_cast<Impl*>(ctx);
 
         if (!me->current_pointer_location)
-            BOOST_THROW_EXCEPTION(std::logic_error("Got wl_pointer.leave when the pointer was not on a surface"));
+            FAIL() << "Got wl_pointer.leave when the pointer was not on a surface";
 
-        // TODO: uncomment this and fix the issue it exposes in Mir (Mir is seding null surfaces)
-        /*
-        if (me->current_pointer_location.value().surface != surface)
-            BOOST_THROW_EXCEPTION(std::logic_error("Got wl_pointer.leave with the wrong surface"));
-        */
+//         TODO: uncomment this and fix the issue it exposes in Mir (Mir is seding null surfaces)
+//         if (me->current_pointer_location.value().surface != surface)
+//             FAIL()
+//                 << "Got wl_pointer.leave with surface " << surface
+//                 << " instead of " << me->current_pointer_location.value().surface;
 
         me->pending_pointer_location = std::experimental::nullopt;
         me->pending_pointer_leave = true;
@@ -1130,7 +1131,7 @@ private:
         auto me = static_cast<Impl*>(ctx);
 
         if (!me->current_pointer_location && !me->pending_pointer_location)
-            BOOST_THROW_EXCEPTION(std::logic_error("Got wl_pointer.motion when the pointer was not on a surface"));
+            FAIL() << "Got wl_pointer.motion when the pointer was not on a surface";
 
         if (!me->pending_pointer_location)
             me->pending_pointer_location = me->current_pointer_location;
@@ -1157,7 +1158,7 @@ private:
         if (me->pending_pointer_leave)
         {
             if (!me->current_pointer_location)
-                BOOST_THROW_EXCEPTION(std::logic_error("Pointer tried to leave when it was not on a surface"));
+                FAIL() << "Pointer tried to leave when it was not on a surface";
 
             wl_surface* old_surface = me->current_pointer_location.value().surface;
             me->current_pointer_location = std::experimental::nullopt;
@@ -1285,7 +1286,7 @@ private:
 
         auto touch = me->current_touches.find(id);
         if (touch != me->current_touches.end())
-            BOOST_THROW_EXCEPTION(std::logic_error("Got wl_touch.down with ID that is already down"));
+            FAIL() << "Got wl_touch.down with ID " << id << " which is already down";
 
         me->pending_touches[id] = SurfaceLocation {
             surface,
@@ -1304,7 +1305,7 @@ private:
 
         auto touch = me->current_touches.find(id);
         if (touch == me->current_touches.end())
-            BOOST_THROW_EXCEPTION(std::logic_error("Got wl_touch.up with unknown ID"));
+            FAIL() << "Got wl_touch.up with unknown ID " << id;
 
         me->pending_up_touches.insert(id);
     }
@@ -1321,7 +1322,7 @@ private:
 
         auto touch = me->current_touches.find(id);
         if (touch == me->current_touches.end())
-            BOOST_THROW_EXCEPTION(std::logic_error("Got wl_touch.motion with unknown ID"));
+            FAIL() << "Got wl_touch.up with unknown ID " << id;
 
         me->pending_touches[id] = SurfaceLocation {
             touch->second.surface,

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -816,6 +816,8 @@ public:
 
     wl_surface* focused_window() const
     {
+        if (pointer_events_pending())
+            BOOST_THROW_EXCEPTION(std::runtime_error("Pointer events pending"));
         if (current_pointer_location)
         {
             return current_pointer_location->surface;
@@ -825,6 +827,8 @@ public:
 
     wl_surface* touched_window() const
     {
+        if (touch_events_pending())
+            BOOST_THROW_EXCEPTION(std::runtime_error("Touch events pending"));
         wl_surface* surface = nullptr;
         for (auto const& touch : current_touches)
         {
@@ -838,11 +842,15 @@ public:
 
     std::pair<wl_fixed_t, wl_fixed_t> pointer_position() const
     {
+        if (pointer_events_pending())
+            BOOST_THROW_EXCEPTION(std::runtime_error("Pointer events pending"));
         return current_pointer_location.value().coordinates;
     };
 
     std::pair<wl_fixed_t, wl_fixed_t> touch_position() const
     {
+        if (touch_events_pending())
+            BOOST_THROW_EXCEPTION(std::runtime_error("Touch events pending"));
         if (current_touches.empty())
             BOOST_THROW_EXCEPTION(std::runtime_error("No touches"));
         else if (current_touches.size() == 1)
@@ -850,6 +858,16 @@ public:
         else
             BOOST_THROW_EXCEPTION(std::runtime_error("More than one touches"));
     };
+
+    bool pointer_events_pending() const
+    {
+        return !pending_buttons.empty() || pending_pointer_location;
+    }
+
+    bool touch_events_pending() const
+    {
+        return !pending_touches.empty() || !pending_up_touches.empty();
+    }
 
     void add_pointer_enter_notification(PointerEnterNotifier const& on_enter)
     {

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -37,6 +37,7 @@
 #include <vector>
 #include <algorithm>
 #include <experimental/optional>
+#include <map>
 #include <unordered_map>
 #include <chrono>
 #include <poll.h>

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -851,16 +851,6 @@ public:
             BOOST_THROW_EXCEPTION(std::logic_error("touch_position() when there are more than 1 touches"));
     };
 
-    bool pointer_events_clean() const
-    {
-        return pending_buttons.empty() && !pending_pointer_location;
-    }
-
-    bool touch_events_clean() const
-    {
-        return pending_touches.empty() && pending_up_touches.empty();
-    }
-
     void add_pointer_enter_notification(PointerEnterNotifier const& on_enter)
     {
         enter_notifiers.push_back(on_enter);
@@ -1656,16 +1646,6 @@ std::pair<wl_fixed_t, wl_fixed_t> wlcs::Client::pointer_position() const
 std::pair<wl_fixed_t, wl_fixed_t> wlcs::Client::touch_position() const
 {
     return impl->touch_position();
-}
-
-bool wlcs::Client::pointer_events_clean() const
-{
-    return impl->pointer_events_clean();
-}
-
-bool wlcs::Client::touch_events_clean() const
-{
-    return impl->touch_events_clean();
 }
 
 void wlcs::Client::add_pointer_enter_notification(PointerEnterNotifier const& on_enter)

--- a/tests/touches.cpp
+++ b/tests/touches.cpp
@@ -18,6 +18,7 @@
 
 #include "helpers.h"
 #include "in_process_server.h"
+#include "xdg_shell_stable.h"
 
 #include <gmock/gmock.h>
 
@@ -195,15 +196,45 @@ INSTANTIATE_TEST_CASE_P(
     TouchTest,
     testing::Values(
         TouchTestParams{
-            "xdg_stable_surface",
+            "window_geom_unset",
             [](wlcs::InProcessServer& server, wlcs::Client& client, int x, int y, int width, int height)
                 -> std::unique_ptr<wlcs::Surface>
                 {
-                    auto surface = client.create_xdg_shell_stable_surface(width, height);
-                    server.the_server().move_surface_to(surface, x, y);
-                    return std::make_unique<wlcs::Surface>(std::move(surface));;
+                    auto surface = std::make_unique<wlcs::Surface>(client);
+                    auto xdg_surface = std::make_shared<wlcs::XdgSurfaceStable>(client, *surface);
+                    auto xdg_toplevel = std::make_shared<wlcs::XdgToplevelStable>(*xdg_surface);
+                    surface->attach_visible_buffer(width, height);
+                    client.run_on_destruction(
+                        [xdg_surface, xdg_toplevel]() mutable
+                        {
+                            xdg_toplevel.reset();
+                            xdg_surface.reset();
+                        });
+                    server.the_server().move_surface_to(*surface, x, y);
+                    return surface;
+                }
+            },
+        TouchTestParams{
+            "window_geom_set",
+            [](wlcs::InProcessServer& server, wlcs::Client& client, int x, int y, int width, int height)
+                -> std::unique_ptr<wlcs::Surface>
+                {
+                    auto surface = std::make_unique<wlcs::Surface>(client);
+                    auto xdg_surface = std::make_shared<wlcs::XdgSurfaceStable>(client, *surface);
+                    auto xdg_toplevel = std::make_shared<wlcs::XdgToplevelStable>(*xdg_surface);
+                    xdg_surface_set_window_geometry(*xdg_surface, 20, 15, width - 25, height - 4);
+                    surface->attach_visible_buffer(width, height);
+                    client.run_on_destruction(
+                        [xdg_surface, xdg_toplevel]() mutable
+                        {
+                            xdg_toplevel.reset();
+                            xdg_surface.reset();
+                        });
+                    server.the_server().move_surface_to(*surface, x + 20, y + 15);
+                    return surface;
                 }
             }
+        // TODO: Add popup test
     ));
 
 INSTANTIATE_TEST_CASE_P(

--- a/tests/touches.cpp
+++ b/tests/touches.cpp
@@ -211,13 +211,29 @@ INSTANTIATE_TEST_CASE_P(
     TouchTest,
     testing::Values(
         TouchTestParams{
-            "subsurface",
+            "not_offset",
             [](wlcs::InProcessServer& server, wlcs::Client& client, int x, int y, int width, int height)
                 -> std::unique_ptr<wlcs::Surface>
                 {
                     auto main_surface = client.create_visible_surface(width, height);
                     server.the_server().move_surface_to(main_surface, x, y);
                     auto subusrface = wlcs::Subsurface::create_visible(main_surface, 0, 0, width, height);
+                    client.run_on_destruction(
+                        [main_surface = std::make_shared<wlcs::Surface>(std::move(main_surface))]() mutable
+                        {
+                            main_surface.reset();
+                        });
+                    return std::make_unique<wlcs::Surface>(std::move(subusrface));
+                }
+            },
+        TouchTestParams{
+            "is_offset",
+            [](wlcs::InProcessServer& server, wlcs::Client& client, int x, int y, int width, int height)
+                -> std::unique_ptr<wlcs::Surface>
+                {
+                    auto main_surface = client.create_visible_surface(width, height);
+                    server.the_server().move_surface_to(main_surface, x - 12, y - 17);
+                    auto subusrface = wlcs::Subsurface::create_visible(main_surface, 12, 17, width, height);
                     client.run_on_destruction(
                         [main_surface = std::make_shared<wlcs::Surface>(std::move(main_surface))]() mutable
                         {


### PR DESCRIPTION
* Ensure touch and pointer events are followed by a `.frame`
* Better (but not complete) support for multiple touches
* Check for various invalid events
  * The `Got wl_pointer.leave with the wrong surface` check exposed https://github.com/MirServer/mir/issues/968, so that needs to be fixed
* Test touches on subsurfaces with an offset
  * Confirmed a bug I'd observed in manual testing: https://github.com/MirServer/mir/issues/967
* Test touches on XDG toplevels with window geometry set
  * Also causes https://github.com/MirServer/mir/issues/967