### PR TITLE
Remove unused code that uses dlvsym()

### DIFF
--- a/include/shared_library.h
+++ b/include/shared_library.h
@@ -43,18 +43,9 @@ public:
     {
         return load_function<FunctionPtr>(function_name.c_str());
     }
-
-    template<typename FunctionPtr>
-    FunctionPtr load_function(std::string const& function_name, std::string const& version) const
-    {
-        FunctionPtr result{};
-        (void*&)result = load_symbol(function_name.c_str(), version.c_str());
-        return result;
-    }
 private:
     void* const so;
     void* load_symbol(char const* function_name) const;
-    void* load_symbol(char const* function_name, char const* version) const;
     SharedLibrary(SharedLibrary const&) = delete;
     SharedLibrary& operator=(SharedLibrary const&) = delete;
 };

--- a/src/shared_library.cpp
+++ b/src/shared_library.cpp
@@ -53,15 +53,3 @@ void* wlcs::SharedLibrary::load_symbol(char const* function_name) const
         BOOST_THROW_EXCEPTION(std::runtime_error(dlerror()));
     }
 }
-
-void* wlcs::SharedLibrary::load_symbol(char const* function_name, char const* version) const
-{
-    if (void* result = dlvsym(so, function_name, version))
-    {
-        return result;
-    }
-    else
-    {
-        BOOST_THROW_EXCEPTION(std::runtime_error(dlerror()));
-    }
-}


### PR DESCRIPTION
Mostly copied from Mir.