### PR TITLE
focused_window -> pointed_at_window

### DIFF
--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -231,7 +231,7 @@ public:
     zxdg_shell_v6* xdg_shell_v6() const;
     xdg_wm_base* xdg_shell_stable() const;
     zwlr_layer_shell_v1* layer_shell_v1() const;
-    wl_surface* focused_window() const;
+    wl_surface* window_under_cursor() const;
     wl_surface* touched_window() const;
     std::pair<wl_fixed_t, wl_fixed_t> pointer_position() const;
     std::pair<wl_fixed_t, wl_fixed_t> touch_position() const;

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -814,7 +814,7 @@ public:
                 "Consider using CheckInterfaceExpected to disable this test when protocol not suppoeted"});
     }
 
-    wl_surface* focused_window() const
+    wl_surface* window_under_cursor() const
     {
         if (pointer_events_pending())
             BOOST_THROW_EXCEPTION(std::runtime_error("Pointer events pending"));
@@ -1646,9 +1646,9 @@ zwlr_layer_shell_v1* wlcs::Client::layer_shell_v1() const
     return impl->the_layer_shell_v1();
 }
 
-wl_surface* wlcs::Client::focused_window() const
+wl_surface* wlcs::Client::window_under_cursor() const
 {
-    return impl->focused_window();
+    return impl->window_under_cursor();
 }
 
 wl_surface* wlcs::Client::touched_window() const

--- a/tests/subsurfaces.cpp
+++ b/tests/subsurfaces.cpp
@@ -50,7 +50,7 @@ struct PointerInputDevice : AbstractInputDevice
 
     wl_surface* focused_window() override
     {
-        return client.focused_window();
+        return client.window_under_cursor();
     }
 
     std::pair<wl_fixed_t, wl_fixed_t> position_on_window() override

--- a/tests/surface_input_regions.cpp
+++ b/tests/surface_input_regions.cpp
@@ -105,13 +105,13 @@ TEST_P(SurfaceWithInputRegions, pointer_seen_entering_and_leaving_input_region)
     pointer.move_to(top_left_x + params.initial_x, top_left_y + params.initial_y);
     client.roundtrip();
 
-    EXPECT_THAT(client.focused_window(), Ne(wl_surface))
+    EXPECT_THAT(client.window_under_cursor(), Ne(wl_surface))
         << "pointer over surface when it should have been outside input region";
 
     pointer.move_by(params.dx, params.dy);
     client.roundtrip();
 
-    ASSERT_THAT(client.focused_window(), Eq(wl_surface))
+    ASSERT_THAT(client.window_under_cursor(), Eq(wl_surface))
         << "pointer not over surface when it should have been in input region";
     EXPECT_THAT(client.pointer_position(),
                 Eq(std::make_pair(
@@ -122,7 +122,7 @@ TEST_P(SurfaceWithInputRegions, pointer_seen_entering_and_leaving_input_region)
     pointer.move_by(-params.dx, -params.dy);
     client.roundtrip();
 
-    EXPECT_THAT(client.focused_window(), Ne(wl_surface))
+    EXPECT_THAT(client.window_under_cursor(), Ne(wl_surface))
         << "pointer over surface when it should have been outside input region";
 }
 
@@ -340,13 +340,13 @@ TEST_P(SurfaceTypesWithInputRegion, pointer_seen_entering_and_leaving_input_regi
     pointer.move_to(top_left_x + params.initial_x, top_left_y + params.initial_y);
     client.roundtrip();
 
-    EXPECT_THAT(client.focused_window(), Ne(wl_surface))
+    EXPECT_THAT(client.window_under_cursor(), Ne(wl_surface))
         << "pointer over surface when it should have been outside input region";
 
     pointer.move_by(params.dx, params.dy);
     client.roundtrip();
 
-    ASSERT_THAT(client.focused_window(), Eq(wl_surface))
+    ASSERT_THAT(client.window_under_cursor(), Eq(wl_surface))
         << "pointer not over surface when it should have been in input region";
     EXPECT_THAT(client.pointer_position(),
                 Eq(std::make_pair(
@@ -357,7 +357,7 @@ TEST_P(SurfaceTypesWithInputRegion, pointer_seen_entering_and_leaving_input_regi
     pointer.move_by(-params.dx, -params.dy);
     client.roundtrip();
 
-    EXPECT_THAT(client.focused_window(), Ne(wl_surface))
+    EXPECT_THAT(client.window_under_cursor(), Ne(wl_surface))
         << "pointer over surface when it should have been outside input region";
 }
 

--- a/tests/test_surface_events.cpp
+++ b/tests/test_surface_events.cpp
@@ -205,14 +205,14 @@ TEST_P(SurfacePointerMotionTest, pointer_movement)
 
     client.roundtrip();
 
-    EXPECT_THAT(client.focused_window(), Ne(wl_surface));
+    EXPECT_THAT(client.window_under_cursor(), Ne(wl_surface));
 
     /* move pointer; it should now be inside the surface */
     pointer.move_by(params.dx, params.dy);
 
     client.roundtrip();
 
-    EXPECT_THAT(client.focused_window(), Eq(wl_surface));
+    EXPECT_THAT(client.window_under_cursor(), Eq(wl_surface));
     EXPECT_THAT(client.pointer_position(),
                 Eq(std::make_pair(
                     wl_fixed_from_int(params.initial_x + params.dx),
@@ -222,7 +222,7 @@ TEST_P(SurfacePointerMotionTest, pointer_movement)
     pointer.move_by(-params.dx, -params.dy);
 
     client.roundtrip();
-    EXPECT_THAT(client.focused_window(), Ne(wl_surface));
+    EXPECT_THAT(client.window_under_cursor(), Ne(wl_surface));
 }
 
 INSTANTIATE_TEST_CASE_P(
@@ -274,7 +274,7 @@ TEST_F(ClientSurfaceEventsTest, surface_moves_under_pointer)
 
     client.roundtrip();
 
-    EXPECT_THAT(client.focused_window(), Ne(wl_surface));
+    EXPECT_THAT(client.window_under_cursor(), Ne(wl_surface));
 
     /* move the surface so that it is under the pointer */
     the_server().move_surface_to(surface, 450, 450);
@@ -282,10 +282,10 @@ TEST_F(ClientSurfaceEventsTest, surface_moves_under_pointer)
     client.dispatch_until(
         [wl_surface, &client]()
         {
-            return client.focused_window() == wl_surface;
+            return client.window_under_cursor() == wl_surface;
         });
 
-    EXPECT_THAT(client.focused_window(), Eq(wl_surface));
+    EXPECT_THAT(client.window_under_cursor(), Eq(wl_surface));
     EXPECT_THAT(client.pointer_position(),
                 Eq(std::make_pair(
                     wl_fixed_from_int(50),
@@ -383,7 +383,7 @@ TEST_F(ClientSurfaceEventsTest, surface_resizes_under_pointer)
 
     client.roundtrip();
 
-    ASSERT_THAT(client.focused_window(), Ne(static_cast<wl_surface*>(surface)));
+    ASSERT_THAT(client.window_under_cursor(), Ne(static_cast<wl_surface*>(surface)));
 
     bool surface_entered{false};
     client.add_pointer_enter_notification(
@@ -451,7 +451,7 @@ TEST_F(ClientSurfaceEventsTest, surface_moves_while_under_pointer)
     client.dispatch_until(
         [&client, &surface]()
         {
-            if (client.focused_window() == surface)
+            if (client.window_under_cursor() == surface)
             {
                 EXPECT_THAT(client.pointer_position().first, Eq(wl_fixed_from_int(50)));
                 EXPECT_THAT(client.pointer_position().second, Eq(wl_fixed_from_int(50)));

--- a/tests/wlr_layer_shell_v1.cpp
+++ b/tests/wlr_layer_shell_v1.cpp
@@ -60,7 +60,7 @@ public:
         pointer.move_to(pos.first + 2, pos.second + 3);
         client.roundtrip();
 
-        EXPECT_THAT(client.focused_window(), Eq((wl_surface*)surface));
+        EXPECT_THAT(client.window_under_cursor(), Eq((wl_surface*)surface));
         EXPECT_THAT(wl_fixed_to_int(client.pointer_position().first), Eq(2));
         EXPECT_THAT(wl_fixed_to_int(client.pointer_position().second), Eq(3));
     }
@@ -532,7 +532,7 @@ TEST_P(LayerSurfaceLayerTest, surface_on_lower_layer_is_initially_placed_below)
     pointer.move_to(1, 1);
     client.roundtrip();
 
-    ASSERT_THAT(client.focused_window(), Eq((wl_surface*)below.surface))
+    ASSERT_THAT(client.window_under_cursor(), Eq((wl_surface*)below.surface))
         << "Test could not run because below surface was not detected when above surface was not in the way";
 
     the_server().move_surface_to(above.surface, 0, 0);
@@ -541,9 +541,9 @@ TEST_P(LayerSurfaceLayerTest, surface_on_lower_layer_is_initially_placed_below)
     pointer.move_to(2, 3);
     client.roundtrip();
 
-    ASSERT_THAT(client.focused_window(), Ne((wl_surface*)below.surface))
+    ASSERT_THAT(client.window_under_cursor(), Ne((wl_surface*)below.surface))
         << "Wrong wurface was on top";
-    ASSERT_THAT(client.focused_window(), Eq((wl_surface*)above.surface))
+    ASSERT_THAT(client.window_under_cursor(), Eq((wl_surface*)above.surface))
         << "Correct surface was not on top";
 }
 
@@ -561,7 +561,7 @@ TEST_P(LayerSurfaceLayerTest, below_surface_can_not_be_raised_with_click)
     pointer.move_to(1, 1);
     client.roundtrip();
 
-    ASSERT_THAT(client.focused_window(), Eq((wl_surface*)below.surface))
+    ASSERT_THAT(client.window_under_cursor(), Eq((wl_surface*)below.surface))
         << "Test could not run because below surface was not detected and clicked on";
 
     pointer.left_button_down();
@@ -571,9 +571,9 @@ TEST_P(LayerSurfaceLayerTest, below_surface_can_not_be_raised_with_click)
     pointer.move_to(width / 2 + 2, 1);
     client.roundtrip();
 
-    ASSERT_THAT(client.focused_window(), Ne((wl_surface*)below.surface))
+    ASSERT_THAT(client.window_under_cursor(), Ne((wl_surface*)below.surface))
         << "Wrong wurface was on top";
-    ASSERT_THAT(client.focused_window(), Eq((wl_surface*)above.surface))
+    ASSERT_THAT(client.window_under_cursor(), Eq((wl_surface*)above.surface))
         << "Correct surface was not on top";
 }
 

--- a/tests/xdg_popup.cpp
+++ b/tests/xdg_popup.cpp
@@ -643,7 +643,7 @@ TEST_P(XdgPopupTest, pointer_focus_goes_to_popup)
     pointer.move_to(manager->window_x + 1, manager->window_y + 1);
     manager->client.roundtrip();
 
-    EXPECT_THAT(manager->client.focused_window(), Eq((wl_surface*)manager->surface));
+    EXPECT_THAT(manager->client.window_under_cursor(), Eq((wl_surface*)manager->surface));
 
     auto positioner = PositionerParams{}
         .with_size(30, 30)
@@ -655,7 +655,7 @@ TEST_P(XdgPopupTest, pointer_focus_goes_to_popup)
     pointer.move_to(manager->window_x + 2, manager->window_y + 1);
     manager->client.roundtrip();
 
-    EXPECT_THAT(manager->client.focused_window(), Eq((wl_surface*)manager->popup_surface.value()));
+    EXPECT_THAT(manager->client.window_under_cursor(), Eq((wl_surface*)manager->popup_surface.value()));
 }
 
 TEST_P(XdgPopupTest, popup_gives_up_pointer_focus_when_gone)
@@ -674,14 +674,14 @@ TEST_P(XdgPopupTest, popup_gives_up_pointer_focus_when_gone)
     pointer.move_to(manager->window_x + 2, manager->window_y + 1);
     manager->client.roundtrip();
 
-    EXPECT_THAT(manager->client.focused_window(), Eq((wl_surface*)manager->popup_surface.value()));
+    EXPECT_THAT(manager->client.window_under_cursor(), Eq((wl_surface*)manager->popup_surface.value()));
 
     manager->unmap_popup();
     manager->client.roundtrip();
     pointer.move_to(manager->window_x + 3, manager->window_y + 1);
     manager->client.roundtrip();
 
-    EXPECT_THAT(manager->client.focused_window(), Eq((wl_surface*)manager->surface));
+    EXPECT_THAT(manager->client.window_under_cursor(), Eq((wl_surface*)manager->surface));
 }
 
 TEST_F(XdgPopupTest, zero_size_anchor_rect_stable)

--- a/tests/xdg_toplevel_stable.cpp
+++ b/tests/xdg_toplevel_stable.cpp
@@ -120,7 +120,7 @@ TEST_F(XdgToplevelStableTest, pointer_respects_window_geom_offset)
     pointer.move_to(pointer_x, pointer_y);
     client.roundtrip();
 
-    ASSERT_THAT(client.focused_window(), Eq((wl_surface*)window.surface));
+    ASSERT_THAT(client.window_under_cursor(), Eq((wl_surface*)window.surface));
     ASSERT_THAT(client.pointer_position(),
                 Ne(std::make_pair(
                     wl_fixed_from_int(pointer_x - window_pos_x),
@@ -213,7 +213,7 @@ TEST_F(XdgToplevelStableTest, interactive_move)
     pointer.move_to(end_x, end_y);
     client.roundtrip();
 
-    EXPECT_THAT(client.focused_window(), Eq(static_cast<struct wl_surface*>(surface)));
+    EXPECT_THAT(client.window_under_cursor(), Eq(static_cast<struct wl_surface*>(surface)));
     EXPECT_THAT(client.pointer_position(),
                 Eq(std::make_pair(
                     wl_fixed_from_int(end_x - window_x - dx),

--- a/tests/xdg_toplevel_v6.cpp
+++ b/tests/xdg_toplevel_v6.cpp
@@ -120,7 +120,7 @@ TEST_F(XdgToplevelV6Test, pointer_respects_window_geom_offset)
     pointer.move_to(pointer_x, pointer_y);
     client.roundtrip();
 
-    ASSERT_THAT(client.focused_window(), Eq((wl_surface*)window.surface));
+    ASSERT_THAT(client.window_under_cursor(), Eq((wl_surface*)window.surface));
     ASSERT_THAT(client.pointer_position(),
                 Ne(std::make_pair(
                     wl_fixed_from_int(pointer_x - window_pos_x),
@@ -213,7 +213,7 @@ TEST_F(XdgToplevelV6Test, interactive_move)
     pointer.move_to(end_x, end_y);
     client.roundtrip();
 
-    EXPECT_THAT(client.focused_window(), Eq(static_cast<struct wl_surface*>(surface)));
+    EXPECT_THAT(client.window_under_cursor(), Eq(static_cast<struct wl_surface*>(surface)));
     EXPECT_THAT(client.pointer_position(),
                 Eq(std::make_pair(
                     wl_fixed_from_int(end_x - window_x - dx),


### PR DESCRIPTION
window "focus" can mean several things, and "has the pointer over it" is rarely one of them.