### PR TITLE
Test wl_output.release

### DIFF
--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -226,6 +226,7 @@ public:
 
     size_t output_count() const;
     OutputState output_state(size_t index) const;
+    void release_output(size_t index);
 
     wl_shell* shell() const;
     zxdg_shell_v6* xdg_shell_v6() const;

--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -226,7 +226,6 @@ public:
 
     size_t output_count() const;
     OutputState output_state(size_t index) const;
-    void release_output(size_t index);
 
     wl_shell* shell() const;
     zxdg_shell_v6* xdg_shell_v6() const;

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -1626,6 +1626,19 @@ wlcs::OutputState wlcs::Client::output_state(size_t index) const
     return impl->outputs[index]->current;
 }
 
+void wlcs::Client::release_output(size_t index)
+{
+    if (index > output_count())
+        throw std::runtime_error("Invalid output index");
+
+    auto const version = wl_output_get_version(impl->outputs[index]->current.output);
+    if (version < WL_OUTPUT_RELEASE_SINCE_VERSION)
+        throw std::runtime_error("Output version " + std::to_string(version) + " too low to support .release");
+
+    wl_output_release(impl->outputs[index]->current.output);
+    impl->outputs.erase(impl->outputs.begin() + index);
+}
+
 wl_shell* wlcs::Client::shell() const
 {
     return impl->the_shell();

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -1621,7 +1621,7 @@ size_t wlcs::Client::output_count() const
 wlcs::OutputState wlcs::Client::output_state(size_t index) const
 {
     if (index > output_count())
-        throw std::runtime_error("Invalid output index");
+        throw std::out_of_range("Invalid output index");
 
     return impl->outputs[index]->current;
 }
@@ -1629,11 +1629,11 @@ wlcs::OutputState wlcs::Client::output_state(size_t index) const
 void wlcs::Client::release_output(size_t index)
 {
     if (index > output_count())
-        throw std::runtime_error("Invalid output index");
+        throw std::out_of_range("Invalid output index");
 
     auto const version = wl_output_get_version(impl->outputs[index]->current.output);
     if (version < WL_OUTPUT_RELEASE_SINCE_VERSION)
-        throw std::runtime_error("Output version " + std::to_string(version) + " too low to support .release");
+        throw std::logic_error("Output version " + std::to_string(version) + " too low to support .release");
 
     wl_output_release(impl->outputs[index]->current.output);
     impl->outputs.erase(impl->outputs.begin() + index);

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -1626,19 +1626,6 @@ wlcs::OutputState wlcs::Client::output_state(size_t index) const
     return impl->outputs[index]->current;
 }
 
-void wlcs::Client::release_output(size_t index)
-{
-    if (index > output_count())
-        throw std::out_of_range("Invalid output index");
-
-    auto const version = wl_output_get_version(impl->outputs[index]->current.output);
-    if (version < WL_OUTPUT_RELEASE_SINCE_VERSION)
-        throw std::logic_error("Output version " + std::to_string(version) + " too low to support .release");
-
-    wl_output_release(impl->outputs[index]->current.output);
-    impl->outputs.erase(impl->outputs.begin() + index);
-}
-
 wl_shell* wlcs::Client::shell() const
 {
     return impl->the_shell();

--- a/tests/wl_output.cpp
+++ b/tests/wl_output.cpp
@@ -39,3 +39,15 @@ TEST_F(WlOutputTest, wl_output_properties_set)
     EXPECT_THAT((bool)output.mode_size, Eq(true));
     EXPECT_THAT((bool)output.scale, Eq(true));
 }
+
+TEST_F(WlOutputTest, wl_output_release)
+{
+    wlcs::Client client{the_server()};
+
+    // Skip test if compositor doesn't support a new enough wl_output version
+    client.acquire_interface(wl_output_interface.name, &wl_output_interface, WL_OUTPUT_RELEASE_SINCE_VERSION);
+
+    ASSERT_THAT(client.output_count(), Ge(1u));
+    client.release_output(0);
+    client.roundtrip();
+}

--- a/tests/wl_output.cpp
+++ b/tests/wl_output.cpp
@@ -44,10 +44,9 @@ TEST_F(WlOutputTest, wl_output_release)
 {
     wlcs::Client client{the_server()};
 
-    // Skip test if compositor doesn't support a new enough wl_output version
-    client.acquire_interface(wl_output_interface.name, &wl_output_interface, WL_OUTPUT_RELEASE_SINCE_VERSION);
-
-    ASSERT_THAT(client.output_count(), Ge(1u));
-    client.release_output(0);
+    // Acquire *any* wl_output; we don't care which
+    auto output = static_cast<wl_output*>(client.acquire_interface(wl_output_interface.name, &wl_output_interface, WL_OUTPUT_RELEASE_SINCE_VERSION));
+    client.roundtrip();
+    wl_output_release(output);
     client.roundtrip();
 }


### PR DESCRIPTION
Tests that the `wl_output.release` request doesn't cause the compositor any trouble (regression test for https://github.com/MirServer/mir/pull/1015)