### PR TITLE
[FAILS ON MIR] Test surfaces get enter/leave events

### DIFF
--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -144,6 +144,7 @@ public:
     std::pair<int, int> pointer_position() const;
 
     Client& owner() const;
+    auto current_outputs() -> std::set<wl_output*> const&;
 
 private:
     class Impl;

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -1821,30 +1821,30 @@ private:
     {
         auto const self = static_cast<Impl*>(data);
 
-        if (self->outputs.find(output) != self->outputs.end())
+        auto const inserted = self->outputs.insert(output);
+
+        if (!inserted.second)
         {
             BOOST_THROW_EXCEPTION(std::runtime_error(
                 "Got wl_surface.enter(wl_output@" +
                 std::to_string(wl_proxy_get_id(reinterpret_cast<wl_proxy*>(output))) +
                 ") for an output the surface is already on"));
         }
-
-        self->outputs.insert(output);
     }
 
     static void on_leave(void* data, wl_surface* /*wl_surface*/, wl_output* output)
     {
         auto const self = static_cast<Impl*>(data);
 
-        if (self->outputs.find(output) == self->outputs.end())
+        auto const erased = self->outputs.erase(output);
+
+        if (!erased)
         {
             BOOST_THROW_EXCEPTION(std::runtime_error(
                 "Got wl_surface.leave(wl_output@" +
                 std::to_string(wl_proxy_get_id(reinterpret_cast<wl_proxy*>(output))) +
                 ") for an output the surface is not on"));
         }
-
-        self->outputs.erase(output);
     }
 
     static constexpr wl_surface_listener surface_listener{

--- a/tests/test_surface_events.cpp
+++ b/tests/test_surface_events.cpp
@@ -588,4 +588,16 @@ TEST_F(ClientSurfaceEventsTest, buffer_release)
     EXPECT_TRUE(buffer_released[2]);
 }
 
+TEST_F(ClientSurfaceEventsTest, surface_enters_output)
+{
+    using namespace testing;
+
+    wlcs::Client client{the_server()};
+
+    auto surface = client.create_visible_surface(100, 100);
+    client.roundtrip();
+
+    EXPECT_THAT(surface.current_outputs(), Not(IsEmpty())) << "Surface did not initially enter output";
+}
+
 // TODO: make parameterized for different types of shell surfaces

--- a/tests/test_surface_events.cpp
+++ b/tests/test_surface_events.cpp
@@ -600,4 +600,21 @@ TEST_F(ClientSurfaceEventsTest, surface_enters_output)
     EXPECT_THAT(surface.current_outputs(), Not(IsEmpty())) << "Surface did not initially enter output";
 }
 
+TEST_F(ClientSurfaceEventsTest, surface_leaves_output)
+{
+    using namespace testing;
+
+    wlcs::Client client{the_server()};
+
+    auto surface = client.create_visible_surface(100, 100);
+    client.roundtrip();
+
+    ASSERT_THAT(surface.current_outputs(), Not(IsEmpty())) << "Precondition failed";
+
+    the_server().move_surface_to(surface, -200, 0);
+    client.roundtrip();
+
+    EXPECT_THAT(surface.current_outputs(), IsEmpty()) << "Did not leave output after being moved off-screen";
+}
+
 // TODO: make parameterized for different types of shell surfaces

--- a/tests/test_surface_events.cpp
+++ b/tests/test_surface_events.cpp
@@ -617,4 +617,23 @@ TEST_F(ClientSurfaceEventsTest, surface_leaves_output)
     EXPECT_THAT(surface.current_outputs(), IsEmpty()) << "Did not leave output after being moved off-screen";
 }
 
+TEST_F(ClientSurfaceEventsTest, surface_renters_output)
+{
+    using namespace testing;
+
+    wlcs::Client client{the_server()};
+
+    auto surface = client.create_visible_surface(100, 100);
+    the_server().move_surface_to(surface, -200, 0);
+    client.roundtrip();
+
+    ASSERT_THAT(surface.current_outputs(), IsEmpty()) << "Precondition failed";
+
+    the_server().move_surface_to(surface, 0, 0);
+    client.roundtrip();
+
+    EXPECT_THAT(surface.current_outputs(), Not(IsEmpty()))
+        << "Surface did not renter output when it moved back on screen";
+}
+
 // TODO: make parameterized for different types of shell surfaces

--- a/tests/test_surface_events.cpp
+++ b/tests/test_surface_events.cpp
@@ -600,40 +600,6 @@ TEST_F(ClientSurfaceEventsTest, surface_enters_output)
     EXPECT_THAT(surface.current_outputs(), Not(IsEmpty())) << "Surface did not initially enter output";
 }
 
-TEST_F(ClientSurfaceEventsTest, surface_leaves_output)
-{
-    using namespace testing;
-
-    wlcs::Client client{the_server()};
-
-    auto surface = client.create_visible_surface(100, 100);
-    client.roundtrip();
-
-    ASSERT_THAT(surface.current_outputs(), Not(IsEmpty())) << "Precondition failed";
-
-    the_server().move_surface_to(surface, -200, 0);
-    client.roundtrip();
-
-    EXPECT_THAT(surface.current_outputs(), IsEmpty()) << "Did not leave output after being moved off-screen";
-}
-
-TEST_F(ClientSurfaceEventsTest, surface_renters_output)
-{
-    using namespace testing;
-
-    wlcs::Client client{the_server()};
-
-    auto surface = client.create_visible_surface(100, 100);
-    the_server().move_surface_to(surface, -200, 0);
-    client.roundtrip();
-
-    ASSERT_THAT(surface.current_outputs(), IsEmpty()) << "Precondition failed";
-
-    the_server().move_surface_to(surface, 0, 0);
-    client.roundtrip();
-
-    EXPECT_THAT(surface.current_outputs(), Not(IsEmpty()))
-        << "Surface did not renter output when it moved back on screen";
-}
+// TODO: test surfaces can leave outputs once we can create multiple outputs
 
 // TODO: make parameterized for different types of shell surfaces


### PR DESCRIPTION
I'm using these tests to implement the enter/leave events on Mir, which are needed for HiDPI support