### PR TITLE
CI: Don't fail if Mir fails a test.

### DIFF
--- a/spread/build/ubuntu/task.yaml
+++ b/spread/build/ubuntu/task.yaml
@@ -25,6 +25,10 @@ execute: |
     cmake -DCMAKE_C_FLAGS="-D_FORTIFY_SOURCE=2" -DCMAKE_CXX_FLAGS="-D_FORTIFY_SOURCE=2" $SPREAD_PATH
     make -j$(nproc)
 
-    # …and check that the Mir tests pass
-    ./wlcs /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/mir/miral_wlcs_integration.so
+    # …and run the Mir tests, but don't fail on them, unless we fail with a signal
+    # TODO: Store the set of passing tests in the Travis cache, and fail if a test which
+    #       previously passed now fails.
+    ./wlcs /usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)/mir/miral_wlcs_integration.so || {
+        test $? -gt 128 -a $? -lt 165
+    }
 


### PR DESCRIPTION
Instead, check that Mir's tests don't die with a signal. That should
be rare enough that this picks up more WLCS bugs than Mir bugs!