### PR TITLE
Test pointer leaves surface during move and resize

### DIFF
--- a/tests/xdg_toplevel_stable.cpp
+++ b/tests/xdg_toplevel_stable.cpp
@@ -164,7 +164,7 @@ TEST_F(XdgToplevelStableTest, touch_respects_window_geom_offset)
 
 // TODO: set_window_geometry window size (something will need to be added to wlcs)
 
-TEST_F(XdgToplevelStableTest, interactive_move)
+TEST_F(XdgToplevelStableTest, surface_can_be_moved_interactively)
 {
     int window_x = 100, window_y = 100;
     int window_width = 420, window_height = 390;
@@ -206,10 +206,6 @@ TEST_F(XdgToplevelStableTest, interactive_move)
     pointer.left_button_up();
     client.roundtrip();
 
-    client.dispatch_until([&](){
-            return !button_down;
-        });
-
     pointer.move_to(end_x, end_y);
     client.roundtrip();
 
@@ -220,6 +216,46 @@ TEST_F(XdgToplevelStableTest, interactive_move)
                     wl_fixed_from_int(end_y - window_y - dy))));
 
     client.roundtrip();
+}
+
+TEST_F(XdgToplevelStableTest, pointer_leaves_surface_during_interactive_move)
+{
+    int window_x = 100, window_y = 100;
+    int window_width = 420, window_height = 390;
+    int start_x = window_x + 5, start_y = window_y + 5;
+
+    wlcs::Client client{the_server()};
+    wlcs::Surface surface{client};
+    wlcs::XdgSurfaceStable xdg_shell_surface{client, surface};
+    wlcs::XdgToplevelStable toplevel{xdg_shell_surface};
+    surface.attach_buffer(window_width, window_height);
+    wl_surface_commit(surface);
+    client.roundtrip();
+
+    the_server().move_surface_to(surface, window_x, window_y);
+
+    auto pointer = the_server().create_pointer();
+
+    bool button_down{false};
+    uint32_t last_serial{0};
+
+    client.add_pointer_button_notification([&](uint32_t serial, uint32_t, bool is_down) -> bool {
+            last_serial = serial;
+            button_down = is_down;
+            return true;
+        });
+
+    pointer.move_to(start_x, start_y);
+    pointer.left_button_down();
+
+    client.dispatch_until([&](){
+            return button_down;
+        });
+
+    xdg_toplevel_move(toplevel, client.seat(), last_serial);
+    client.dispatch_until([&](){
+            return !button_down;
+        });
 }
 
 TEST_F(XdgToplevelStableTest, parent_can_be_set)

--- a/tests/xdg_toplevel_stable.cpp
+++ b/tests/xdg_toplevel_stable.cpp
@@ -258,6 +258,100 @@ TEST_F(XdgToplevelStableTest, pointer_leaves_surface_during_interactive_move)
         });
 }
 
+TEST_F(XdgToplevelStableTest, surface_can_be_resized_interactively)
+{
+    int window_x = 100, window_y = 100;
+    int window_width = 420, window_height = 390;
+    int start_x = window_x + 5, start_y = window_y + 5;
+    int dx = 60, dy = -40;
+    int end_x = window_x + dx + 20, end_y = window_y + dy + 20;
+
+    wlcs::Client client{the_server()};
+    wlcs::Surface surface{client};
+    wlcs::XdgSurfaceStable xdg_shell_surface{client, surface};
+    wlcs::XdgToplevelStable toplevel{xdg_shell_surface};
+    surface.attach_buffer(window_width, window_height);
+    wl_surface_commit(surface);
+    client.roundtrip();
+
+    the_server().move_surface_to(surface, window_x, window_y);
+
+    auto pointer = the_server().create_pointer();
+
+    bool button_down{false};
+    uint32_t last_serial{0};
+
+    client.add_pointer_button_notification([&](uint32_t serial, uint32_t, bool is_down) -> bool {
+            last_serial = serial;
+            button_down = is_down;
+            return true;
+        });
+
+    pointer.move_to(start_x, start_y);
+    pointer.left_button_down();
+
+    client.dispatch_until([&](){
+            return button_down;
+        });
+
+    xdg_toplevel_resize(toplevel, client.seat(), last_serial, XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT);
+    client.roundtrip();
+    pointer.move_to(start_x + dx, start_x + dy);
+    pointer.left_button_up();
+    client.roundtrip();
+
+    pointer.move_to(end_x, end_y);
+    client.roundtrip();
+
+    EXPECT_THAT(client.window_under_cursor(), Eq(static_cast<struct wl_surface*>(surface)));
+    EXPECT_THAT(client.pointer_position(),
+                Eq(std::make_pair(
+                    wl_fixed_from_int(end_x - window_x - dx),
+                    wl_fixed_from_int(end_y - window_y - dy))));
+
+    client.roundtrip();
+}
+
+TEST_F(XdgToplevelStableTest, pointer_leaves_surface_during_interactive_resize)
+{
+    int window_x = 100, window_y = 100;
+    int window_width = 420, window_height = 390;
+    int start_x = window_x + 5, start_y = window_y + 5;
+
+    wlcs::Client client{the_server()};
+    wlcs::Surface surface{client};
+    wlcs::XdgSurfaceStable xdg_shell_surface{client, surface};
+    wlcs::XdgToplevelStable toplevel{xdg_shell_surface};
+    surface.attach_buffer(window_width, window_height);
+    wl_surface_commit(surface);
+    client.roundtrip();
+
+    the_server().move_surface_to(surface, window_x, window_y);
+
+    auto pointer = the_server().create_pointer();
+
+    bool button_down{false};
+    uint32_t last_serial{0};
+
+    client.add_pointer_button_notification([&](uint32_t serial, uint32_t, bool is_down) -> bool {
+            last_serial = serial;
+            button_down = is_down;
+            return true;
+        });
+
+    pointer.move_to(start_x, start_y);
+    pointer.left_button_down();
+
+    client.dispatch_until([&](){
+            return button_down;
+        });
+
+    xdg_toplevel_resize(toplevel, client.seat(), last_serial, XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT);
+    client.dispatch_until([&](){
+            return !button_down;
+        });
+}
+
 TEST_F(XdgToplevelStableTest, parent_can_be_set)
 {
     const int window_pos_x = 200, window_pos_y = 280;
@@ -287,10 +381,6 @@ TEST_F(XdgToplevelStableTest, null_parent_can_be_set)
     wl_surface_commit(window.surface);
     client.roundtrip();
 }
-
-// TODO: interactive resize
-// This would probably make sense as a parameterized test, with resizing in all directions
-// Like move, resize is not implemented in the current WLCS window manager, and should not be tested until it is
 
 using XdgToplevelStableConfigurationTest = wlcs::InProcessServer;
 

--- a/tests/xdg_toplevel_stable.cpp
+++ b/tests/xdg_toplevel_stable.cpp
@@ -254,7 +254,7 @@ TEST_F(XdgToplevelStableTest, pointer_leaves_surface_during_interactive_move)
 
     xdg_toplevel_move(toplevel, client.seat(), last_serial);
     client.dispatch_until([&](){
-            return !button_down;
+            return !client.window_under_cursor();
         });
 }
 
@@ -348,7 +348,7 @@ TEST_F(XdgToplevelStableTest, pointer_leaves_surface_during_interactive_resize)
 
     xdg_toplevel_resize(toplevel, client.seat(), last_serial, XDG_TOPLEVEL_RESIZE_EDGE_TOP_LEFT);
     client.dispatch_until([&](){
-            return !button_down;
+            return !client.window_under_cursor();
         });
 }
 

--- a/tests/xdg_toplevel_v6.cpp
+++ b/tests/xdg_toplevel_v6.cpp
@@ -259,7 +259,7 @@ TEST_F(XdgToplevelV6Test, pointer_leaves_surface_during_interactive_move)
 
     zxdg_toplevel_v6_move(toplevel, client.seat(), last_serial);
     client.dispatch_until([&](){
-            return !button_down;
+            return !client.window_under_cursor();
         });
 }
 
@@ -353,7 +353,7 @@ TEST_F(XdgToplevelV6Test, pointer_leaves_surface_during_interactive_resize)
 
     zxdg_toplevel_v6_resize(toplevel, client.seat(), last_serial, ZXDG_TOPLEVEL_V6_RESIZE_EDGE_TOP_LEFT);
     client.dispatch_until([&](){
-            return !button_down;
+            return !client.window_under_cursor();
         });
 }
 

--- a/tests/xdg_toplevel_v6.cpp
+++ b/tests/xdg_toplevel_v6.cpp
@@ -164,7 +164,7 @@ TEST_F(XdgToplevelV6Test, touch_respects_window_geom_offset)
 
 // TODO: set_window_geometry window size (something will need to be added to wlcs)
 
-TEST_F(XdgToplevelV6Test, interactive_move)
+TEST_F(XdgToplevelV6Test, surface_can_be_moved_interactively)
 {
     int window_x = 100, window_y = 100;
     int window_width = 420, window_height = 390;
@@ -220,6 +220,141 @@ TEST_F(XdgToplevelV6Test, interactive_move)
                     wl_fixed_from_int(end_y - window_y - dy))));
 
     client.roundtrip();
+}
+
+
+TEST_F(XdgToplevelV6Test, pointer_leaves_surface_during_interactive_move)
+{
+    int window_x = 100, window_y = 100;
+    int window_width = 420, window_height = 390;
+    int start_x = window_x + 5, start_y = window_y + 5;
+
+    wlcs::Client client{the_server()};
+    wlcs::Surface surface{client};
+    wlcs::XdgSurfaceV6 xdg_shell_surface{client, surface};
+    wlcs::XdgToplevelV6 toplevel{xdg_shell_surface};
+    surface.attach_buffer(window_width, window_height);
+    wl_surface_commit(surface);
+    client.roundtrip();
+
+    the_server().move_surface_to(surface, window_x, window_y);
+
+    auto pointer = the_server().create_pointer();
+
+    bool button_down{false};
+    uint32_t last_serial{0};
+
+    client.add_pointer_button_notification([&](uint32_t serial, uint32_t, bool is_down) -> bool {
+            last_serial = serial;
+            button_down = is_down;
+            return true;
+        });
+
+    pointer.move_to(start_x, start_y);
+    pointer.left_button_down();
+
+    client.dispatch_until([&](){
+            return button_down;
+        });
+
+    zxdg_toplevel_v6_move(toplevel, client.seat(), last_serial);
+    client.dispatch_until([&](){
+            return !button_down;
+        });
+}
+
+TEST_F(XdgToplevelV6Test, surface_can_be_resized_interactively)
+{
+    int window_x = 100, window_y = 100;
+    int window_width = 420, window_height = 390;
+    int start_x = window_x + 5, start_y = window_y + 5;
+    int dx = 60, dy = -40;
+    int end_x = window_x + dx + 20, end_y = window_y + dy + 20;
+
+    wlcs::Client client{the_server()};
+    wlcs::Surface surface{client};
+    wlcs::XdgSurfaceV6 xdg_shell_surface{client, surface};
+    wlcs::XdgToplevelV6 toplevel{xdg_shell_surface};
+    surface.attach_buffer(window_width, window_height);
+    wl_surface_commit(surface);
+    client.roundtrip();
+
+    the_server().move_surface_to(surface, window_x, window_y);
+
+    auto pointer = the_server().create_pointer();
+
+    bool button_down{false};
+    uint32_t last_serial{0};
+
+    client.add_pointer_button_notification([&](uint32_t serial, uint32_t, bool is_down) -> bool {
+            last_serial = serial;
+            button_down = is_down;
+            return true;
+        });
+
+    pointer.move_to(start_x, start_y);
+    pointer.left_button_down();
+
+    client.dispatch_until([&](){
+            return button_down;
+        });
+
+    zxdg_toplevel_v6_resize(toplevel, client.seat(), last_serial, ZXDG_TOPLEVEL_V6_RESIZE_EDGE_TOP_LEFT);
+    client.roundtrip();
+    pointer.move_to(start_x + dx, start_x + dy);
+    pointer.left_button_up();
+    client.roundtrip();
+
+    pointer.move_to(end_x, end_y);
+    client.roundtrip();
+
+    EXPECT_THAT(client.window_under_cursor(), Eq(static_cast<struct wl_surface*>(surface)));
+    EXPECT_THAT(client.pointer_position(),
+                Eq(std::make_pair(
+                    wl_fixed_from_int(end_x - window_x - dx),
+                    wl_fixed_from_int(end_y - window_y - dy))));
+
+    client.roundtrip();
+}
+
+TEST_F(XdgToplevelV6Test, pointer_leaves_surface_during_interactive_resize)
+{
+    int window_x = 100, window_y = 100;
+    int window_width = 420, window_height = 390;
+    int start_x = window_x + 5, start_y = window_y + 5;
+
+    wlcs::Client client{the_server()};
+    wlcs::Surface surface{client};
+    wlcs::XdgSurfaceV6 xdg_shell_surface{client, surface};
+    wlcs::XdgToplevelV6 toplevel{xdg_shell_surface};
+    surface.attach_buffer(window_width, window_height);
+    wl_surface_commit(surface);
+    client.roundtrip();
+
+    the_server().move_surface_to(surface, window_x, window_y);
+
+    auto pointer = the_server().create_pointer();
+
+    bool button_down{false};
+    uint32_t last_serial{0};
+
+    client.add_pointer_button_notification([&](uint32_t serial, uint32_t, bool is_down) -> bool {
+            last_serial = serial;
+            button_down = is_down;
+            return true;
+        });
+
+    pointer.move_to(start_x, start_y);
+    pointer.left_button_down();
+
+    client.dispatch_until([&](){
+            return button_down;
+        });
+
+    zxdg_toplevel_v6_resize(toplevel, client.seat(), last_serial, ZXDG_TOPLEVEL_V6_RESIZE_EDGE_TOP_LEFT);
+    client.dispatch_until([&](){
+            return !button_down;
+        });
 }
 
 TEST_F(XdgToplevelV6Test, parent_can_be_set)


### PR DESCRIPTION
Adds a test for XDG surfaces interactive resize, and tests that the cursor leaves the surface during move and resize. The latter currently fails on Mir for both cases and for both v6 and stable.