### PR TITLE
Add surface type and input method abstractions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ set(
   include/wl_interface_descriptor.h
   include/layer_shell_v1.h
   include/surface_builder.h
+  include/input_method.h
 
   src/data_device.cpp
   src/gtk_primary_selection.cpp
@@ -164,6 +165,7 @@ set(
   src/xdg_output_v1.cpp
   src/version_specifier.cpp
   src/surface_builder.cpp
+  src/input_method.cpp
 
   ${PROTOCOL_SOURCES}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ set(
   include/version_specifier.h
   include/wl_interface_descriptor.h
   include/layer_shell_v1.h
+  include/surface_builder.h
 
   src/data_device.cpp
   src/gtk_primary_selection.cpp
@@ -162,6 +163,7 @@ set(
   src/thread_proxy.h
   src/xdg_output_v1.cpp
   src/version_specifier.cpp
+  src/surface_builder.cpp
 
   ${PROTOCOL_SOURCES}
 

--- a/include/input_method.h
+++ b/include/input_method.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#ifndef WLCS_INPUT_METHOD_H_
+#define WLCS_INPUT_METHOD_H_
+
+#include <string>
+#include <vector>
+#include "in_process_server.h"
+
+namespace wlcs
+{
+
+struct InputMethod
+{
+    InputMethod(std::string const& name) : name{name} {}
+    virtual ~InputMethod() = default;
+
+    struct Device
+    {
+        virtual ~Device() = default;
+        virtual void drag_or_move_to_position(std::pair<int, int> position) = 0;
+        virtual void down() = 0; ///< does nothing for touches
+        virtual void up() = 0;
+
+        void to_position(std::pair<int, int> position)
+        {
+            up();
+            drag_or_move_to_position(position);
+        }
+    };
+
+    virtual auto create_device(wlcs::Server& server) -> std::unique_ptr<Device> = 0;
+    virtual auto current_surface(wlcs::Client const& client) -> wl_surface* = 0;
+    virtual auto position_on_surface(wlcs::Client const& client) -> std::pair<int, int> = 0;
+
+    static auto all_input_methods() -> std::vector<std::shared_ptr<InputMethod>>;
+
+    std::string const name;
+};
+
+struct PointerInputMethod : InputMethod
+{
+    PointerInputMethod() : InputMethod{"pointer"} {}
+
+    struct Pointer;
+
+    auto create_device(wlcs::Server& server) -> std::unique_ptr<Device> override;
+    auto current_surface(wlcs::Client const& client) -> wl_surface* override;
+    auto position_on_surface(wlcs::Client const& client) -> std::pair<int, int> override;
+};
+
+struct TouchInputMethod : InputMethod
+{
+    TouchInputMethod() : InputMethod{"touch"} {}
+
+    struct Touch;
+
+    auto create_device(wlcs::Server& server) -> std::unique_ptr<Device> override;
+    auto current_surface(wlcs::Client const& client) -> wl_surface* override;
+    auto position_on_surface(wlcs::Client const& client) -> std::pair<int, int> override;
+};
+
+}
+
+std::ostream& operator<<(std::ostream& out, std::shared_ptr<wlcs::InputMethod> const& param);
+
+#endif // WLCS_INPUT_METHOD_H_

--- a/include/input_method.h
+++ b/include/input_method.h
@@ -34,15 +34,13 @@ struct InputMethod
     struct Device
     {
         virtual ~Device() = default;
-        virtual void drag_or_move_to_position(std::pair<int, int> position) = 0;
-        virtual void down() = 0; ///< does nothing for touches
-        virtual void up() = 0;
-
-        void to_position(std::pair<int, int> position)
-        {
-            up();
-            drag_or_move_to_position(position);
-        }
+        /// 1. Unclicks button or raises touch if currently "down"
+        /// 2. Moves to new positon
+        /// 3. Touches/clicks down at that new position
+        virtual void move_to(std::pair<int, int> position) = 0;
+        /// MUST be called in the "down" state (can not be the first call)
+        /// Moves device to new position while remaining in the "down" state
+        virtual void drag_to(std::pair<int, int> position) = 0;
     };
 
     virtual auto create_device(wlcs::Server& server) -> std::unique_ptr<Device> = 0;

--- a/include/input_method.h
+++ b/include/input_method.h
@@ -34,13 +34,12 @@ struct InputMethod
     struct Device
     {
         virtual ~Device() = default;
-        /// 1. Unclicks button or raises touch if currently "down"
-        /// 2. Moves to new positon
-        /// 3. Touches/clicks down at that new position
+        /// Can only be called while decice is up
+        virtual void down_at(std::pair<int, int> position) = 0;
+        /// Can only be called while device is down
         virtual void move_to(std::pair<int, int> position) = 0;
-        /// MUST be called in the "down" state (can not be the first call)
-        /// Moves device to new position while remaining in the "down" state
-        virtual void drag_to(std::pair<int, int> position) = 0;
+        /// Can only be called while device is down
+        virtual void up() = 0;
     };
 
     virtual auto create_device(wlcs::Server& server) -> std::unique_ptr<Device> = 0;

--- a/include/surface_builder.h
+++ b/include/surface_builder.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#ifndef WLCS_SURFACE_BUILDER_H_
+#define WLCS_SURFACE_BUILDER_H_
+
+#include <string>
+#include <vector>
+#include "in_process_server.h"
+
+namespace wlcs
+{
+
+struct SurfaceBuilder
+{
+    SurfaceBuilder(std::string const& name) : name{name} {}
+    virtual ~SurfaceBuilder() = default;
+
+    virtual auto build(
+        wlcs::Server& server,
+        wlcs::Client& client,
+        std::pair<int, int> position,
+        std::pair<int, int> size) const -> std::unique_ptr<wlcs::Surface> = 0;
+
+    std::string const name;
+
+    static auto all_surface_types() -> std::vector<std::shared_ptr<SurfaceBuilder>>;
+    static auto toplevel_surface_types() -> std::vector<std::shared_ptr<SurfaceBuilder>>;
+};
+
+struct WlShellSurfaceBuilder : SurfaceBuilder
+{
+    WlShellSurfaceBuilder() : SurfaceBuilder{"wl_shell_surface"} {}
+
+    auto build(
+        wlcs::Server& server,
+        wlcs::Client& client,
+        std::pair<int, int> position,
+        std::pair<int, int> size) const -> std::unique_ptr<wlcs::Surface> override;
+};
+
+struct XdgV6SurfaceBuilder : SurfaceBuilder
+{
+    XdgV6SurfaceBuilder() : SurfaceBuilder{"zxdg_surface_v6"} {}
+
+    auto build(
+        wlcs::Server& server,
+        wlcs::Client& client,
+        std::pair<int, int> position,
+        std::pair<int, int> size) const -> std::unique_ptr<wlcs::Surface> override;
+};
+
+struct XdgStableSurfaceBuilder : SurfaceBuilder
+{
+    XdgStableSurfaceBuilder() : SurfaceBuilder{"xdg_surface (stable)"} {}
+
+    auto build(
+        wlcs::Server& server,
+        wlcs::Client& client,
+        std::pair<int, int> position,
+        std::pair<int, int> size) const -> std::unique_ptr<wlcs::Surface> override;
+};
+
+struct SubsurfaceBuilder : SurfaceBuilder
+{
+    SubsurfaceBuilder(std::pair<int, int> offset);
+
+    auto build(
+        wlcs::Server& server,
+        wlcs::Client& client,
+        std::pair<int, int> position,
+        std::pair<int, int> size) const -> std::unique_ptr<wlcs::Surface> override;
+
+    std::pair<int, int> offset;
+};
+
+// TODO: popup surfaces
+}
+
+std::ostream& operator<<(std::ostream& out, std::shared_ptr<wlcs::SurfaceBuilder> const& param);
+
+#endif // WLCS_SURFACE_BUILDER_H_

--- a/src/input_method.cpp
+++ b/src/input_method.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "input_method.h"
+
+auto wlcs::InputMethod::all_input_methods() -> std::vector<std::shared_ptr<InputMethod>>
+{
+    // All this pointer casting nonsense is only to make 16.04 GCC happy
+    return {
+        std::static_pointer_cast<InputMethod>(std::make_shared<PointerInputMethod>()),
+        std::static_pointer_cast<InputMethod>(std::make_shared<TouchInputMethod>())};
+}
+
+struct wlcs::PointerInputMethod::Pointer : Device
+{
+    Pointer(wlcs::Server& server)
+        : pointer{server.create_pointer()}
+    {
+    }
+
+    void drag_or_move_to_position(std::pair<int, int> position) override
+    {
+        pointer.move_to(position.first, position.second);
+    }
+
+    void down() override
+    {
+        if (!button_down)
+        {
+            pointer.left_button_down();
+            button_down = true;
+        }
+    }
+
+    void up() override
+    {
+        if (button_down)
+        {
+            pointer.left_button_up();
+            button_down = false;
+        }
+    }
+
+    wlcs::Pointer pointer;
+    bool button_down = false;
+};
+
+auto wlcs::PointerInputMethod::create_device(wlcs::Server& server) -> std::unique_ptr<Device>
+{
+    return std::make_unique<Pointer>(server);
+}
+
+auto wlcs::PointerInputMethod::current_surface(wlcs::Client const& client) -> wl_surface*
+{
+    return client.window_under_cursor();
+}
+
+auto wlcs::PointerInputMethod::position_on_surface(wlcs::Client const& client) -> std::pair<int, int>
+{
+    auto const wl_fixed_position = client.pointer_position();
+    return {
+        wl_fixed_to_int(wl_fixed_position.first),
+        wl_fixed_to_int(wl_fixed_position.second)};
+}
+
+struct wlcs::TouchInputMethod::Touch : Device
+{
+    Touch(wlcs::Server& server)
+        : touch{server.create_touch()}
+    {
+    }
+
+    void drag_or_move_to_position(std::pair<int, int> position) override
+    {
+        if (is_down)
+        {
+            touch.move_to(position.first, position.second);
+        }
+        else
+        {
+            touch.down_at(position.first, position.second);
+        }
+        is_down = true;
+    }
+
+    void down() override
+    {
+    }
+
+    void up() override
+    {
+        touch.up();
+        is_down = false;
+    }
+
+    wlcs::Touch touch;
+    bool is_down = false;
+};
+
+auto wlcs::TouchInputMethod::create_device(wlcs::Server& server) -> std::unique_ptr<Device>
+{
+    return std::make_unique<Touch>(server);
+}
+
+auto wlcs::TouchInputMethod::current_surface(wlcs::Client const& client) -> wl_surface*
+{
+    return client.touched_window();
+}
+
+auto wlcs::TouchInputMethod::position_on_surface(wlcs::Client const& client) -> std::pair<int, int>
+{
+    auto const wl_fixed_position = client.touch_position();
+    return {
+        wl_fixed_to_int(wl_fixed_position.first),
+        wl_fixed_to_int(wl_fixed_position.second)};
+}
+
+std::ostream& operator<<(std::ostream& out, std::shared_ptr<wlcs::InputMethod> const& param)
+{
+    return out << param->name;
+}

--- a/src/input_method.cpp
+++ b/src/input_method.cpp
@@ -33,21 +33,25 @@ struct wlcs::PointerInputMethod::Pointer : Device
     {
     }
 
-    void move_to(std::pair<int, int> position) override
+    void down_at(std::pair<int, int> position) override
     {
-        if (button_down)
-        {
-            pointer.left_button_up();
-        }
+        ASSERT_THAT(button_down, testing::Eq(false)) << "Called down_at() with pointer already down";
         pointer.move_to(position.first, position.second);
         pointer.left_button_down();
         button_down = true;
     }
 
-    void drag_to(std::pair<int, int> position) override
+    void move_to(std::pair<int, int> position) override
     {
-        ASSERT_THAT(button_down, testing::Eq(true)) << "Called drag_to() while pointer is in the \"up\" state";
+        ASSERT_THAT(button_down, testing::Eq(true)) << "Called move_to() with pointer up";
         pointer.move_to(position.first, position.second);
+    }
+
+    void up() override
+    {
+        ASSERT_THAT(button_down, testing::Eq(true)) << "Called up() with pointer already up";
+        pointer.left_button_up();
+        button_down = false;
     }
 
     wlcs::Pointer pointer;
@@ -79,21 +83,24 @@ struct wlcs::TouchInputMethod::Touch : Device
     {
     }
 
-    void move_to(std::pair<int, int> position) override
+    void down_at(std::pair<int, int> position) override
     {
-        if (is_down)
-        {
-            touch.up();
-
-        }
+        ASSERT_THAT(is_down, testing::Eq(false)) << "Called down_at() with touch already down";
         touch.down_at(position.first, position.second);
         is_down = true;
     }
 
-    void drag_to(std::pair<int, int> position) override
+    void move_to(std::pair<int, int> position) override
     {
-        ASSERT_THAT(is_down, testing::Eq(true)) << "Called drag_to() while touch is in the \"up\" state";
+        ASSERT_THAT(is_down, testing::Eq(true)) << "Called move_to() with touch up";
         touch.move_to(position.first, position.second);
+    }
+
+    void up() override
+    {
+        ASSERT_THAT(is_down, testing::Eq(true)) << "Called up() with touch already up";
+        touch.up();
+        is_down = false;
     }
 
     wlcs::Touch touch;

--- a/src/input_method.cpp
+++ b/src/input_method.cpp
@@ -21,10 +21,9 @@
 
 auto wlcs::InputMethod::all_input_methods() -> std::vector<std::shared_ptr<InputMethod>>
 {
-    // All this pointer casting nonsense is only to make 16.04 GCC happy
     return {
-        std::static_pointer_cast<InputMethod>(std::make_shared<PointerInputMethod>()),
-        std::static_pointer_cast<InputMethod>(std::make_shared<TouchInputMethod>())};
+        std::make_shared<PointerInputMethod>(),
+        std::make_shared<TouchInputMethod>()};
 }
 
 struct wlcs::PointerInputMethod::Pointer : Device

--- a/src/surface_builder.cpp
+++ b/src/surface_builder.cpp
@@ -20,22 +20,20 @@
 
 auto wlcs::SurfaceBuilder::all_surface_types() -> std::vector<std::shared_ptr<SurfaceBuilder>>
 {
-    // All this pointer casting nonsense is only to make 16.04 GCC happy
     return {
-        std::static_pointer_cast<SurfaceBuilder>(std::make_shared<WlShellSurfaceBuilder>()),
-        std::static_pointer_cast<SurfaceBuilder>(std::make_shared<XdgV6SurfaceBuilder>()),
-        std::static_pointer_cast<SurfaceBuilder>(std::make_shared<XdgStableSurfaceBuilder>()),
-        std::static_pointer_cast<SurfaceBuilder>(std::make_shared<SubsurfaceBuilder>(std::make_pair(0, 0))),
-        std::static_pointer_cast<SurfaceBuilder>(std::make_shared<SubsurfaceBuilder>(std::make_pair(7, 12)))};
+        std::make_shared<WlShellSurfaceBuilder>(),
+        std::make_shared<XdgV6SurfaceBuilder>(),
+        std::make_shared<XdgStableSurfaceBuilder>(),
+        std::make_shared<SubsurfaceBuilder>(std::make_pair(0, 0)),
+        std::make_shared<SubsurfaceBuilder>(std::make_pair(7, 12))};
 }
 
 auto wlcs::SurfaceBuilder::toplevel_surface_types() -> std::vector<std::shared_ptr<SurfaceBuilder>>
 {
-    // All this pointer casting nonsense is only to make 16.04 GCC happy
     return {
-        std::static_pointer_cast<SurfaceBuilder>(std::make_shared<WlShellSurfaceBuilder>()),
-        std::static_pointer_cast<SurfaceBuilder>(std::make_shared<XdgV6SurfaceBuilder>()),
-        std::static_pointer_cast<SurfaceBuilder>(std::make_shared<XdgStableSurfaceBuilder>())};
+        std::make_shared<WlShellSurfaceBuilder>(),
+        std::make_shared<XdgV6SurfaceBuilder>(),
+        std::make_shared<XdgStableSurfaceBuilder>()};
 }
 
 auto wlcs::WlShellSurfaceBuilder::build(

--- a/src/surface_builder.cpp
+++ b/src/surface_builder.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright © 2020 Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authored by: William Wold <william.wold@canonical.com>
+ */
+
+#include "surface_builder.h"
+
+auto wlcs::SurfaceBuilder::all_surface_types() -> std::vector<std::shared_ptr<SurfaceBuilder>>
+{
+    // All this pointer casting nonsense is only to make 16.04 GCC happy
+    return {
+        std::static_pointer_cast<SurfaceBuilder>(std::make_shared<WlShellSurfaceBuilder>()),
+        std::static_pointer_cast<SurfaceBuilder>(std::make_shared<XdgV6SurfaceBuilder>()),
+        std::static_pointer_cast<SurfaceBuilder>(std::make_shared<XdgStableSurfaceBuilder>()),
+        std::static_pointer_cast<SurfaceBuilder>(std::make_shared<SubsurfaceBuilder>(std::make_pair(0, 0))),
+        std::static_pointer_cast<SurfaceBuilder>(std::make_shared<SubsurfaceBuilder>(std::make_pair(7, 12)))};
+}
+
+auto wlcs::SurfaceBuilder::toplevel_surface_types() -> std::vector<std::shared_ptr<SurfaceBuilder>>
+{
+    // All this pointer casting nonsense is only to make 16.04 GCC happy
+    return {
+        std::static_pointer_cast<SurfaceBuilder>(std::make_shared<WlShellSurfaceBuilder>()),
+        std::static_pointer_cast<SurfaceBuilder>(std::make_shared<XdgV6SurfaceBuilder>()),
+        std::static_pointer_cast<SurfaceBuilder>(std::make_shared<XdgStableSurfaceBuilder>())};
+}
+
+auto wlcs::WlShellSurfaceBuilder::build(
+    wlcs::Server& server,
+    wlcs::Client& client,
+    std::pair<int, int> position,
+    std::pair<int, int> size) const -> std::unique_ptr<wlcs::Surface>
+{
+    auto surface = std::make_unique<wlcs::Surface>(
+        client.create_wl_shell_surface(size.first, size.second));
+    server.move_surface_to(*surface, position.first, position.second);
+    return surface;
+}
+
+auto wlcs::XdgV6SurfaceBuilder::build(
+    wlcs::Server& server,
+    wlcs::Client& client,
+    std::pair<int, int> position,
+    std::pair<int, int> size) const -> std::unique_ptr<wlcs::Surface>
+{
+    auto surface = std::make_unique<wlcs::Surface>(
+        client.create_xdg_shell_v6_surface(size.first, size.second));
+    server.move_surface_to(*surface, position.first, position.second);
+    return surface;
+}
+
+auto wlcs::XdgStableSurfaceBuilder::build(
+    wlcs::Server& server,
+    wlcs::Client& client,
+    std::pair<int, int> position,
+    std::pair<int, int> size) const -> std::unique_ptr<wlcs::Surface>
+{
+    auto surface = std::make_unique<wlcs::Surface>(
+        client.create_xdg_shell_stable_surface(size.first, size.second));
+    server.move_surface_to(*surface, position.first, position.second);
+    return surface;
+}
+
+wlcs::SubsurfaceBuilder::SubsurfaceBuilder(std::pair<int, int> offset)
+    : SurfaceBuilder{
+        "subsurface (offset " +
+        std::to_string(offset.first) +
+        ", " +
+        std::to_string(offset.second) +
+        ")"},
+        offset{offset}
+{
+}
+
+auto wlcs::SubsurfaceBuilder::build(
+    wlcs::Server& server,
+    wlcs::Client& client,
+    std::pair<int, int> position,
+    std::pair<int, int> size) const -> std::unique_ptr<wlcs::Surface>
+{
+    auto main_surface = std::make_shared<wlcs::Surface>(
+        client.create_visible_surface(80, 50));
+    server.move_surface_to(
+        *main_surface,
+        position.first - offset.first,
+        position.second - offset.second);
+    client.run_on_destruction(
+        [main_surface]() mutable
+        {
+            main_surface.reset();
+        });
+    auto subsurface = std::make_unique<wlcs::Subsurface>(wlcs::Subsurface::create_visible(
+        *main_surface,
+        offset.first, offset.second,
+        size.first, size.second));
+    // if subsurface is sync, tests would have to commit the parent to modify it
+    // this is inconvenient to do in a generic way, so we make it desync
+    wl_subsurface_set_desync(*subsurface);
+    return subsurface;
+}
+
+std::ostream& operator<<(std::ostream& out, std::shared_ptr<wlcs::SurfaceBuilder> const& param)
+{
+    return out << param->name;
+}

--- a/tests/surface_input_regions.cpp
+++ b/tests/surface_input_regions.cpp
@@ -289,7 +289,7 @@ TEST_P(RegionSurfaceInputCombinations, input_inside_region_seen)
     struct wl_surface* const wl_surface = *surface;
 
     auto const device = input->create_device(the_server());
-    device->to_position({
+    device->move_to({
         top_left.first + region.on_surface.first,
         top_left.second + region.on_surface.second});
     client.roundtrip();
@@ -322,11 +322,11 @@ TEST_P(RegionSurfaceInputCombinations, input_not_seen_after_leaving_region)
     struct wl_surface* const wl_surface = *surface;
 
     auto const device = input->create_device(the_server());
-    device->to_position({
+    device->move_to({
         top_left.first + region.on_surface.first,
         top_left.second + region.on_surface.second});
     client.roundtrip();
-    device->to_position({
+    device->move_to({
         top_left.first + region.off_surface.first,
         top_left.second + region.off_surface.second});
     client.roundtrip();
@@ -365,7 +365,7 @@ TEST_P(SurfaceInputCombinations, input_not_seen_in_region_after_null_buffer_comm
     client.roundtrip();
 
     auto const device = input->create_device(the_server());
-    device->to_position(top_left);
+    device->move_to(top_left);
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(wl_surface))
@@ -391,7 +391,7 @@ TEST_P(SurfaceInputCombinations, input_not_seen_in_surface_without_region_after_
     client.roundtrip();
 
     auto const device = input->create_device(the_server());
-    device->to_position(top_left);
+    device->move_to(top_left);
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(wl_surface))
@@ -420,7 +420,7 @@ TEST_P(SurfaceInputCombinations, input_not_seen_over_empty_region)
     client.roundtrip();
 
     auto const device = input->create_device(the_server());
-    device->to_position({top_left.first + 4, top_left.second + 4});
+    device->move_to({top_left.first + 4, top_left.second + 4});
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(wl_surface))
@@ -453,7 +453,7 @@ TEST_P(SurfaceInputCombinations, input_hits_parent_after_falling_through_subsurf
     region.apply_to_surface(client, sub_wl_surface);
 
     auto const device = input->create_device(the_server());
-    device->to_position({top_left.first + input_offset.first, top_left.second + input_offset.second});
+    device->move_to({top_left.first + input_offset.first, top_left.second + input_offset.second});
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(sub_wl_surface))
@@ -493,7 +493,7 @@ TEST_P(SurfaceInputCombinations, unmapping_parent_stops_subsurface_getting_input
     client.roundtrip();
 
     auto const device = input->create_device(the_server());
-    device->to_position({top_left.first + 4, top_left.second + 4});
+    device->move_to({top_left.first + 4, top_left.second + 4});
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(parent_wl_surface))
@@ -535,7 +535,7 @@ TEST_P(SurfaceInputCombinations, input_falls_through_subsurface_when_unmapped)
     client.roundtrip();
 
     auto const device = input->create_device(the_server());
-    device->to_position({top_left.first - 90, top_left.second + 10});
+    device->move_to({top_left.first - 90, top_left.second + 10});
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(sub_wl_surface))
@@ -580,7 +580,7 @@ TEST_P(SurfaceInputCombinations, input_falls_through_subsurface_when_parent_unma
     client.roundtrip();
 
     auto const device = input->create_device(the_server());
-    device->to_position({top_left.first - 90, top_left.second + 10});
+    device->move_to({top_left.first - 90, top_left.second + 10});
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(sub_wl_surface))
@@ -616,7 +616,7 @@ TEST_P(SurfaceInputCombinations, input_seen_after_surface_unmapped_and_remapped)
     surface->attach_visible_buffer(surface_size.first, surface_size.second);
 
     auto const device = input->create_device(the_server());
-    device->to_position({top_left.first + input_offset.first, top_left.second + input_offset.second});
+    device->move_to({top_left.first + input_offset.first, top_left.second + input_offset.second});
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Eq(wl_surface))
@@ -659,7 +659,7 @@ TEST_P(SurfaceInputCombinations, input_seen_by_subsurface_after_parent_unmapped_
     //the_server().move_surface_to(*parent, top_left.first, top_left.second);
 
     auto const device = input->create_device(the_server());
-    device->to_position({top_left.first + input_offset.first, top_left.second + input_offset.second});
+    device->move_to({top_left.first + input_offset.first, top_left.second + input_offset.second});
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(parent_wl_surface))
@@ -695,11 +695,9 @@ TEST_P(SurfaceInputCombinations, input_seen_after_dragged_off_surface)
     client.roundtrip();
 
     auto const device = input->create_device(the_server());
-    device->to_position({top_left.first + 5, top_left.second + 5});
-    device->down();
+    device->move_to({top_left.first + 5, top_left.second + 5});
     client.roundtrip();
-
-    device->drag_or_move_to_position({top_left.first + input_offset.first, top_left.second + input_offset.second});
+    device->drag_to({top_left.first + input_offset.first, top_left.second + input_offset.second});
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(other_wl_surface))
@@ -736,15 +734,11 @@ TEST_P(SurfaceInputCombinations, input_seen_by_second_surface_after_drag_off_fir
     client.roundtrip();
 
     auto const device = input->create_device(the_server());
-    device->to_position({top_left.first + 5, top_left.second + 5});
-    device->down();
+    device->move_to({top_left.first + 5, top_left.second + 5});
     client.roundtrip();
-
-    device->drag_or_move_to_position({top_left.first - 80, top_left.second + 5});
+    device->drag_to({top_left.first - 80, top_left.second + 5});
     client.roundtrip();
-
-    device->up();
-    device->drag_or_move_to_position({top_left.first - 80, top_left.second + 5});
+    device->move_to({top_left.first - 80, top_left.second + 5});
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(main_wl_surface))
@@ -786,7 +780,7 @@ TEST_P(ToplevelInputCombinations, input_falls_through_surface_without_region_aft
     client.roundtrip();
 
     auto const device = input->create_device(the_server());
-    device->to_position(top_left);
+    device->move_to(top_left);
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(upper_wl_surface))

--- a/tests/surface_input_regions.cpp
+++ b/tests/surface_input_regions.cpp
@@ -289,7 +289,7 @@ TEST_P(RegionSurfaceInputCombinations, input_inside_region_seen)
     struct wl_surface* const wl_surface = *surface;
 
     auto const device = input->create_device(the_server());
-    device->move_to({
+    device->down_at({
         top_left.first + region.on_surface.first,
         top_left.second + region.on_surface.second});
     client.roundtrip();
@@ -322,11 +322,12 @@ TEST_P(RegionSurfaceInputCombinations, input_not_seen_after_leaving_region)
     struct wl_surface* const wl_surface = *surface;
 
     auto const device = input->create_device(the_server());
-    device->move_to({
+    device->down_at({
         top_left.first + region.on_surface.first,
         top_left.second + region.on_surface.second});
     client.roundtrip();
-    device->move_to({
+    device->up();
+    device->down_at({
         top_left.first + region.off_surface.first,
         top_left.second + region.off_surface.second});
     client.roundtrip();
@@ -365,7 +366,7 @@ TEST_P(SurfaceInputCombinations, input_not_seen_in_region_after_null_buffer_comm
     client.roundtrip();
 
     auto const device = input->create_device(the_server());
-    device->move_to(top_left);
+    device->down_at(top_left);
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(wl_surface))
@@ -391,7 +392,7 @@ TEST_P(SurfaceInputCombinations, input_not_seen_in_surface_without_region_after_
     client.roundtrip();
 
     auto const device = input->create_device(the_server());
-    device->move_to(top_left);
+    device->down_at(top_left);
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(wl_surface))
@@ -420,7 +421,7 @@ TEST_P(SurfaceInputCombinations, input_not_seen_over_empty_region)
     client.roundtrip();
 
     auto const device = input->create_device(the_server());
-    device->move_to({top_left.first + 4, top_left.second + 4});
+    device->down_at({top_left.first + 4, top_left.second + 4});
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(wl_surface))
@@ -453,7 +454,7 @@ TEST_P(SurfaceInputCombinations, input_hits_parent_after_falling_through_subsurf
     region.apply_to_surface(client, sub_wl_surface);
 
     auto const device = input->create_device(the_server());
-    device->move_to({top_left.first + input_offset.first, top_left.second + input_offset.second});
+    device->down_at({top_left.first + input_offset.first, top_left.second + input_offset.second});
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(sub_wl_surface))
@@ -493,7 +494,7 @@ TEST_P(SurfaceInputCombinations, unmapping_parent_stops_subsurface_getting_input
     client.roundtrip();
 
     auto const device = input->create_device(the_server());
-    device->move_to({top_left.first + 4, top_left.second + 4});
+    device->down_at({top_left.first + 4, top_left.second + 4});
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(parent_wl_surface))
@@ -535,7 +536,7 @@ TEST_P(SurfaceInputCombinations, input_falls_through_subsurface_when_unmapped)
     client.roundtrip();
 
     auto const device = input->create_device(the_server());
-    device->move_to({top_left.first - 90, top_left.second + 10});
+    device->down_at({top_left.first - 90, top_left.second + 10});
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(sub_wl_surface))
@@ -580,7 +581,7 @@ TEST_P(SurfaceInputCombinations, input_falls_through_subsurface_when_parent_unma
     client.roundtrip();
 
     auto const device = input->create_device(the_server());
-    device->move_to({top_left.first - 90, top_left.second + 10});
+    device->down_at({top_left.first - 90, top_left.second + 10});
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(sub_wl_surface))
@@ -616,7 +617,7 @@ TEST_P(SurfaceInputCombinations, input_seen_after_surface_unmapped_and_remapped)
     surface->attach_visible_buffer(surface_size.first, surface_size.second);
 
     auto const device = input->create_device(the_server());
-    device->move_to({top_left.first + input_offset.first, top_left.second + input_offset.second});
+    device->down_at({top_left.first + input_offset.first, top_left.second + input_offset.second});
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Eq(wl_surface))
@@ -659,7 +660,7 @@ TEST_P(SurfaceInputCombinations, input_seen_by_subsurface_after_parent_unmapped_
     //the_server().move_surface_to(*parent, top_left.first, top_left.second);
 
     auto const device = input->create_device(the_server());
-    device->move_to({top_left.first + input_offset.first, top_left.second + input_offset.second});
+    device->down_at({top_left.first + input_offset.first, top_left.second + input_offset.second});
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(parent_wl_surface))
@@ -695,9 +696,9 @@ TEST_P(SurfaceInputCombinations, input_seen_after_dragged_off_surface)
     client.roundtrip();
 
     auto const device = input->create_device(the_server());
-    device->move_to({top_left.first + 5, top_left.second + 5});
+    device->down_at({top_left.first + 5, top_left.second + 5});
     client.roundtrip();
-    device->drag_to({top_left.first + input_offset.first, top_left.second + input_offset.second});
+    device->move_to({top_left.first + input_offset.first, top_left.second + input_offset.second});
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(other_wl_surface))
@@ -734,11 +735,12 @@ TEST_P(SurfaceInputCombinations, input_seen_by_second_surface_after_drag_off_fir
     client.roundtrip();
 
     auto const device = input->create_device(the_server());
-    device->move_to({top_left.first + 5, top_left.second + 5});
-    client.roundtrip();
-    device->drag_to({top_left.first - 80, top_left.second + 5});
+    device->down_at({top_left.first + 5, top_left.second + 5});
     client.roundtrip();
     device->move_to({top_left.first - 80, top_left.second + 5});
+    client.roundtrip();
+    device->up();
+    device->down_at({top_left.first - 80, top_left.second + 5});
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(main_wl_surface))
@@ -780,7 +782,7 @@ TEST_P(ToplevelInputCombinations, input_falls_through_surface_without_region_aft
     client.roundtrip();
 
     auto const device = input->create_device(the_server());
-    device->move_to(top_left);
+    device->down_at(top_left);
     client.roundtrip();
 
     EXPECT_THAT(input->current_surface(client), Ne(upper_wl_surface))


### PR DESCRIPTION
This moves the abstractions added in #156 into WLCS proper. This allows parameterized tests to easily test with all the input methods and surface types they desire (instead of the patchwork of flowed approaches we currently employ).