### PR TITLE
Fix SurfaceBuilder/InputMethod stream operators

### DIFF
--- a/include/input_method.h
+++ b/include/input_method.h
@@ -75,6 +75,9 @@ struct TouchInputMethod : InputMethod
 
 }
 
+namespace std
+{
 std::ostream& operator<<(std::ostream& out, std::shared_ptr<wlcs::InputMethod> const& param);
+}
 
 #endif // WLCS_INPUT_METHOD_H_

--- a/include/surface_builder.h
+++ b/include/surface_builder.h
@@ -92,6 +92,9 @@ struct SubsurfaceBuilder : SurfaceBuilder
 // TODO: popup surfaces
 }
 
+namespace std
+{
 std::ostream& operator<<(std::ostream& out, std::shared_ptr<wlcs::SurfaceBuilder> const& param);
+}
 
 #endif // WLCS_SURFACE_BUILDER_H_

--- a/src/input_method.cpp
+++ b/src/input_method.cpp
@@ -125,7 +125,7 @@ auto wlcs::TouchInputMethod::position_on_surface(wlcs::Client const& client) -> 
         wl_fixed_to_int(wl_fixed_position.second)};
 }
 
-std::ostream& operator<<(std::ostream& out, std::shared_ptr<wlcs::InputMethod> const& param)
+std::ostream& std::operator<<(std::ostream& out, std::shared_ptr<wlcs::InputMethod> const& param)
 {
     return out << param->name;
 }

--- a/src/surface_builder.cpp
+++ b/src/surface_builder.cpp
@@ -110,7 +110,7 @@ auto wlcs::SubsurfaceBuilder::build(
     return subsurface;
 }
 
-std::ostream& operator<<(std::ostream& out, std::shared_ptr<wlcs::SurfaceBuilder> const& param)
+std::ostream& std::operator<<(std::ostream& out, std::shared_ptr<wlcs::SurfaceBuilder> const& param)
 {
     return out << param->name;
 }


### PR DESCRIPTION
To work with gtest, these operators need to be in `std`