### PR TITLE
Use XDG surface with geometry

### DIFF
--- a/include/surface_builder.h
+++ b/include/surface_builder.h
@@ -67,13 +67,15 @@ struct XdgV6SurfaceBuilder : SurfaceBuilder
 
 struct XdgStableSurfaceBuilder : SurfaceBuilder
 {
-    XdgStableSurfaceBuilder() : SurfaceBuilder{"xdg_surface (stable)"} {}
+    XdgStableSurfaceBuilder(int left_offset, int top_offset, int right_offset, int bottom_offset);
 
     auto build(
         wlcs::Server& server,
         wlcs::Client& client,
         std::pair<int, int> position,
         std::pair<int, int> size) const -> std::unique_ptr<wlcs::Surface> override;
+
+    int left_offset, top_offset, right_offset, bottom_offset;
 };
 
 struct SubsurfaceBuilder : SurfaceBuilder

--- a/src/surface_builder.cpp
+++ b/src/surface_builder.cpp
@@ -25,6 +25,7 @@ auto wlcs::SurfaceBuilder::all_surface_types() -> std::vector<std::shared_ptr<Su
         std::make_shared<WlShellSurfaceBuilder>(),
         std::make_shared<XdgV6SurfaceBuilder>(),
         std::make_shared<XdgStableSurfaceBuilder>(0, 0, 0, 0),
+        std::make_shared<XdgStableSurfaceBuilder>(12, 5, 20, 6),
         std::make_shared<SubsurfaceBuilder>(std::make_pair(0, 0)),
         std::make_shared<SubsurfaceBuilder>(std::make_pair(7, 12))};
 }

--- a/tests/surface_input_regions.cpp
+++ b/tests/surface_input_regions.cpp
@@ -108,7 +108,7 @@ std::ostream& operator<<(std::ostream& out, RegionWithTestPoints const& param)
 auto const all_surface_types = ValuesIn(wlcs::SurfaceBuilder::all_surface_types());
 auto const toplevel_surface_types = ValuesIn(wlcs::SurfaceBuilder::toplevel_surface_types());
 auto const xdg_stable_surface_type = Values(
-    std::static_pointer_cast<wlcs::SurfaceBuilder>(std::make_shared<wlcs::XdgStableSurfaceBuilder>()));
+    std::static_pointer_cast<wlcs::SurfaceBuilder>(std::make_shared<wlcs::XdgStableSurfaceBuilder>(0, 0, 0, 0)));
 
 auto const all_input_types = ValuesIn(wlcs::InputMethod::all_input_methods());
 


### PR DESCRIPTION
Allow the XDG surface builder to set the window geometry and add a surface with geometry set to `all_surface_types`