### PR TITLE
Improve Layer Shell tests

### DIFF
--- a/tests/xdg_popup.cpp
+++ b/tests/xdg_popup.cpp
@@ -399,6 +399,7 @@ public:
         : XdgPopupManagerBase{in_process_server},
           layer_surface{client, surface}
     {
+        zwlr_layer_surface_v1_set_size(layer_surface, window_width, window_height);
         wait_for_frame_to_render();
     }
 


### PR DESCRIPTION
Improvements include:
- Always set size when required by the protocol
- Test margins
- Test popups are placed correctly (The XDG popup test already tests a verity of positioners for Layer Shell popups, but this tests a verity of layer surface configurations with the same basic positioner)

A bit of refactoring was required.