### PR TITLE
CI: Update Alpine & Fedora images

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -24,7 +24,7 @@ jobs:
         - lxd:ubuntu-devel:...:clang
         - lxd:fedora-31:...:gcc
         - lxd:fedora-32:...:gcc
-        - lxd:alpine-3.11:...:gcc
+        - lxd:alpine-3.13:...:gcc
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -22,8 +22,8 @@ jobs:
         - lxd:ubuntu-20.04:...:gcc
         - lxd:ubuntu-devel:...:gcc
         - lxd:ubuntu-devel:...:clang
-        - lxd:fedora-31:...:gcc
         - lxd:fedora-32:...:gcc
+        - lxd:fedora-33:...:gcc
         - lxd:alpine-3.13:...:gcc
 
     runs-on: ubuntu-latest

--- a/spread.yaml
+++ b/spread.yaml
@@ -9,8 +9,8 @@ backends:
             - ubuntu-20.04
             - ubuntu-devel:
                 image: ubuntu-daily:devel/amd64
-            - fedora-31
             - fedora-32
+            - fedora-33
             - alpine-3.13
 
 suites:

--- a/spread.yaml
+++ b/spread.yaml
@@ -11,7 +11,7 @@ backends:
                 image: ubuntu-daily:devel/amd64
             - fedora-31
             - fedora-32
-            - alpine-3.11
+            - alpine-3.13
 
 suites:
     spread/build/:


### PR DESCRIPTION
Fedora 31 isn't available anymore according to https://us.images.linuxcontainers.org/

And Alpine Linux 3.13 is available since a month or so https://alpinelinux.org/releases/