### PR TITLE
Add tests for popup done event

### DIFF
--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -170,9 +170,6 @@ public:
     void attach_visible_buffer(int width, int height);
     void run_on_destruction(std::function<void()> callback);
 
-    bool has_focus() const;
-    std::pair<int, int> pointer_position() const;
-
     Client& owner() const;
 
 private:
@@ -259,6 +256,7 @@ public:
     wl_pointer* the_pointer() const;
     zxdg_shell_v6* xdg_shell_v6() const;
     xdg_wm_base* xdg_shell_stable() const;
+    wl_surface* keyboard_focused_window() const;
     wl_surface* window_under_cursor() const;
     wl_surface* touched_window() const;
     std::pair<wl_fixed_t, wl_fixed_t> pointer_position() const;

--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -263,6 +263,7 @@ public:
     wl_surface* touched_window() const;
     std::pair<wl_fixed_t, wl_fixed_t> pointer_position() const;
     std::pair<wl_fixed_t, wl_fixed_t> touch_position() const;
+    std::experimental::optional<uint32_t> latest_serial() const;
 
     using PointerEnterNotifier =
         std::function<bool(wl_surface*, wl_fixed_t x, wl_fixed_t y)>;

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -1069,18 +1069,19 @@ private:
     static void keyboard_enter(
         void* ctx,
         wl_keyboard*,
-        uint32_t /*serial*/,
+        uint32_t serial,
         wl_surface *surface,
         wl_array* /*keys*/)
     {
         auto me = static_cast<Impl*>(ctx);
         me->keyboard_focused_surface = surface;
+        me->latest_serial_ = serial;
     }
 
     static void keyboard_leave(
         void *ctx,
         wl_keyboard*,
-        uint32_t /*serial*/,
+        uint32_t serial,
         wl_surface* surface)
     {
         auto me = static_cast<Impl*>(ctx);
@@ -1088,10 +1089,19 @@ private:
         {
             me->keyboard_focused_surface = nullptr;
         }
+        me->latest_serial_ = serial;
     }
 
-    static void keyboard_key(void*, wl_keyboard*, uint32_t, uint32_t, uint32_t, uint32_t)
+    static void keyboard_key(
+        void* ctx,
+        wl_keyboard*,
+        uint32_t serial,
+        uint32_t /*time*/,
+        uint32_t /*key*/,
+        uint32_t /*state*/)
     {
+        auto me = static_cast<Impl*>(ctx);
+        me->latest_serial_ = serial;
     }
 
     static void keyboard_modifiers(void*, wl_keyboard*, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t)

--- a/tests/xdg_popup.cpp
+++ b/tests/xdg_popup.cpp
@@ -181,7 +181,7 @@ public:
         setup_popup(params);
         wl_surface_commit(popup_surface.value());
         dispatch_until_popup_configure();
-        popup_surface.value().attach_buffer(popup_width, popup_height);
+        popup_surface.value().attach_buffer(params.popup_size.first, params.popup_size.second);
         bool surface_rendered{false};
         popup_surface.value().add_frame_callback([&surface_rendered](auto) { surface_rendered = true; });
         wl_surface_commit(popup_surface.value());

--- a/tests/xdg_popup.cpp
+++ b/tests/xdg_popup.cpp
@@ -737,29 +737,6 @@ TEST_P(XdgPopupTest, grabbed_popup_gets_done_event_when_new_toplevel_created)
     manager->client.create_visible_surface(window_width, window_height);
 }
 
-TEST_P(XdgPopupTest, non_grabbed_popup_gets_done_event_when_new_toplevel_created)
-{
-    auto const& param = GetParam();
-    auto manager = param.build(this);
-    auto pointer = the_server().create_pointer();
-
-    // This is needed to get a serial, which will be used later on
-    pointer.move_to(manager->window_x + 2, manager->window_y + 2);
-    pointer.left_click();
-    manager->client.roundtrip();
-
-    auto positioner = PositionerParams{}
-        .with_size(30, 30)
-        .with_anchor(XDG_POSITIONER_ANCHOR_TOP_LEFT)
-        .with_gravity(XDG_POSITIONER_GRAVITY_BOTTOM_RIGHT);
-    manager->map_popup(positioner);
-    manager->client.roundtrip();
-
-    EXPECT_CALL(*manager, popup_done());
-
-    manager->client.create_visible_surface(window_width, window_height);
-}
-
 TEST_P(XdgPopupTest, grabbed_popup_does_not_get_keyboard_focus)
 {
     auto const& param = GetParam();

--- a/tests/xdg_popup.cpp
+++ b/tests/xdg_popup.cpp
@@ -737,6 +737,29 @@ TEST_P(XdgPopupTest, grabbed_popup_gets_done_event_when_new_toplevel_created)
     manager->client.create_visible_surface(window_width, window_height);
 }
 
+TEST_P(XdgPopupTest, non_grabbed_popup_gets_done_event_when_new_toplevel_created)
+{
+    auto const& param = GetParam();
+    auto manager = param.build(this);
+    auto pointer = the_server().create_pointer();
+
+    // This is needed to get a serial, which will be used later on
+    pointer.move_to(manager->window_x + 2, manager->window_y + 2);
+    pointer.left_click();
+    manager->client.roundtrip();
+
+    auto positioner = PositionerParams{}
+        .with_size(30, 30)
+        .with_anchor(XDG_POSITIONER_ANCHOR_TOP_LEFT)
+        .with_gravity(XDG_POSITIONER_GRAVITY_BOTTOM_RIGHT);
+    manager->map_popup(positioner);
+    manager->client.roundtrip();
+
+    EXPECT_CALL(*manager, popup_done());
+
+    manager->client.create_visible_surface(window_width, window_height);
+}
+
 TEST_P(XdgPopupTest, does_not_get_popup_done_event_before_button_press)
 {
     auto const& param = GetParam();

--- a/tests/xdg_popup.cpp
+++ b/tests/xdg_popup.cpp
@@ -760,6 +760,55 @@ TEST_P(XdgPopupTest, non_grabbed_popup_gets_done_event_when_new_toplevel_created
     manager->client.create_visible_surface(window_width, window_height);
 }
 
+TEST_P(XdgPopupTest, grabbed_popup_does_not_get_keyboard_focus)
+{
+    auto const& param = GetParam();
+    auto manager = param.build(this);
+    auto pointer = the_server().create_pointer();
+
+    // This is needed to get a serial, which will be used later on
+    pointer.move_to(manager->window_x + 2, manager->window_y + 2);
+    pointer.left_click();
+    manager->client.roundtrip();
+
+    auto positioner = PositionerParams{}
+        .with_size(30, 30)
+        .with_anchor(XDG_POSITIONER_ANCHOR_TOP_LEFT)
+        .with_gravity(XDG_POSITIONER_GRAVITY_BOTTOM_RIGHT)
+        .with_grab();
+    manager->map_popup(positioner);
+    manager->client.roundtrip();
+
+    EXPECT_THAT(
+        manager->client.keyboard_focused_window(),
+        Ne(static_cast<wl_surface*>(manager->popup_surface.value())))
+        << "popup given keyboard focus";
+    EXPECT_THAT(
+        manager->client.keyboard_focused_window(),
+        Eq(static_cast<wl_surface*>(manager->surface)));
+}
+
+TEST_P(XdgPopupTest, non_grabbed_popup_does_not_get_keyboard_focus)
+{
+    auto const& param = GetParam();
+    auto manager = param.build(this);
+
+    auto positioner = PositionerParams{}
+        .with_size(30, 30)
+        .with_anchor(XDG_POSITIONER_ANCHOR_TOP_LEFT)
+        .with_gravity(XDG_POSITIONER_GRAVITY_BOTTOM_RIGHT);
+    manager->map_popup(positioner);
+    manager->client.roundtrip();
+
+    EXPECT_THAT(
+        manager->client.keyboard_focused_window(),
+        Ne(static_cast<wl_surface*>(manager->popup_surface.value())))
+        << "popup given keyboard focus";
+    EXPECT_THAT(
+        manager->client.keyboard_focused_window(),
+        Eq(static_cast<wl_surface*>(manager->surface)));
+}
+
 TEST_P(XdgPopupTest, does_not_get_popup_done_event_before_button_press)
 {
     auto const& param = GetParam();


### PR DESCRIPTION
Adds tests that we get a popup done event when popups are dismissed. `does_not_get_popup_done_event_before_button_press` fails due to https://github.com/MirServer/mir/issues/1818. I made the client remember the last serial it got, so we don't need to wire up pointer listeners when that's all we care about.