### PR TITLE
Add wlcs::Client::latest_serial() and wl_keyboard

### DIFF
--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -170,9 +170,6 @@ public:
     void attach_visible_buffer(int width, int height);
     void run_on_destruction(std::function<void()> callback);
 
-    bool has_focus() const;
-    std::pair<int, int> pointer_position() const;
-
     Client& owner() const;
 
 private:
@@ -259,6 +256,7 @@ public:
     wl_pointer* the_pointer() const;
     zxdg_shell_v6* xdg_shell_v6() const;
     xdg_wm_base* xdg_shell_stable() const;
+    wl_surface* keyboard_focused_window() const;
     wl_surface* window_under_cursor() const;
     wl_surface* touched_window() const;
     std::pair<wl_fixed_t, wl_fixed_t> pointer_position() const;

--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -263,6 +263,7 @@ public:
     wl_surface* touched_window() const;
     std::pair<wl_fixed_t, wl_fixed_t> pointer_position() const;
     std::pair<wl_fixed_t, wl_fixed_t> touch_position() const;
+    std::experimental::optional<uint32_t> latest_serial() const;
 
     using PointerEnterNotifier =
         std::function<bool(wl_surface*, wl_fixed_t x, wl_fixed_t y)>;

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -1069,18 +1069,19 @@ private:
     static void keyboard_enter(
         void* ctx,
         wl_keyboard*,
-        uint32_t /*serial*/,
+        uint32_t serial,
         wl_surface *surface,
         wl_array* /*keys*/)
     {
         auto me = static_cast<Impl*>(ctx);
         me->keyboard_focused_surface = surface;
+        me->latest_serial_ = serial;
     }
 
     static void keyboard_leave(
         void *ctx,
         wl_keyboard*,
-        uint32_t /*serial*/,
+        uint32_t serial,
         wl_surface* surface)
     {
         auto me = static_cast<Impl*>(ctx);
@@ -1088,10 +1089,19 @@ private:
         {
             me->keyboard_focused_surface = nullptr;
         }
+        me->latest_serial_ = serial;
     }
 
-    static void keyboard_key(void*, wl_keyboard*, uint32_t, uint32_t, uint32_t, uint32_t)
+    static void keyboard_key(
+        void* ctx,
+        wl_keyboard*,
+        uint32_t serial,
+        uint32_t /*time*/,
+        uint32_t /*key*/,
+        uint32_t /*state*/)
     {
+        auto me = static_cast<Impl*>(ctx);
+        me->latest_serial_ = serial;
     }
 
     static void keyboard_modifiers(void*, wl_keyboard*, uint32_t, uint32_t, uint32_t, uint32_t, uint32_t)


### PR DESCRIPTION
Support getting the latest serial sent from the compositor (useful for popup grabs, and possibly other things in the future). Adding `wl_keyboard` makes sure new surfaces have a serial once they're focused, and provides access to keyboard focus.