### PR TITLE
[spread] allow `ubuntu-devel` and `fedora-33` to fail for now

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -22,13 +22,15 @@ jobs:
         - lxd:ubuntu-21.04:...:gcc
         - lxd:ubuntu-21.04:...:clang
         - lxd:fedora-32:...:gcc
-        - lxd:fedora-33:...:gcc
+        - lxd:fedora-34:...:gcc
         - lxd:alpine-3.13:...:gcc
         allow-fail: [false]
         include:
         - spread-task: lxd:ubuntu-devel:...:gcc
           allow-fail: true
         - spread-task: lxd:ubuntu-devel:...:clang
+          allow-fail: true
+        - spread-task: lxd:fedora-33:...:gcc
           allow-fail: true
 
     runs-on: ubuntu-latest

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -19,11 +19,17 @@ jobs:
       matrix:
         spread-task:
         - lxd:ubuntu-20.04:...:gcc
-        - lxd:ubuntu-devel:...:gcc
-        - lxd:ubuntu-devel:...:clang
+        - lxd:ubuntu-21.04:...:gcc
+        - lxd:ubuntu-21.04:...:clang
         - lxd:fedora-32:...:gcc
         - lxd:fedora-33:...:gcc
         - lxd:alpine-3.13:...:gcc
+        allow-fail: [false]
+        include:
+        - spread-task: lxd:ubuntu-devel:...:gcc
+          allow-fail: true
+        - spread-task: lxd:ubuntu-devel:...:clang
+          allow-fail: true
 
     runs-on: ubuntu-latest
 
@@ -55,6 +61,7 @@ jobs:
       env:
         LXD_DIR: /var/snap/lxd/common/lxd
       run: sg lxd -c 'snap run spread -v ${{ matrix.spread-task }}'
+      continue-on-error: ${{ matrix.allow-fail }}
 
   # Report result to Bors on `staging` and `trying` branches.
   Bors:

--- a/spread.yaml
+++ b/spread.yaml
@@ -6,6 +6,7 @@ backends:
     lxd:
         systems:
             - ubuntu-20.04
+            - ubuntu-21.04
             - ubuntu-devel:
                 image: ubuntu-daily:devel/amd64
             - fedora-32

--- a/spread.yaml
+++ b/spread.yaml
@@ -11,6 +11,7 @@ backends:
                 image: ubuntu-daily:devel/amd64
             - fedora-32
             - fedora-33
+            - fedora-34
             - alpine-3.13
 
 suites:


### PR DESCRIPTION
It's not open yet / Fedora doesn't get an IP.