### PR TITLE
cmake: always set GTEST_LIBRARY if it isn't

### DIFF
--- a/cmake/FindGtestGmock.cmake
+++ b/cmake/FindGtestGmock.cmake
@@ -39,6 +39,12 @@ if (NOT GTEST_FOUND)
     find_package_handle_standard_args(GTest GTEST_LIBRARY GTEST_BOTH_LIBRARIES GTEST_INCLUDE_DIRS)
 endif()
 
+# Upstream GTestConfig.cmake doesn't provide GTEST_LIBRARY but GTEST_LIBRARIES
+# CMake 3.20+ uses the upstream gtest config if possible.
+if (NOT DEFINED GTEST_LIBRARY)
+    set(GTEST_LIBRARY ${GTEST_LIBRARIES})
+endif()
+
 find_file(GMOCK_SOURCE
         NAMES gmock-all.cc
         DOC "GMock source"
@@ -63,11 +69,6 @@ if (EXISTS ${GMOCK_SOURCE})
 else()
     # Assume gmock is no longer source, we'll find out soon enough if that's wrong
     add_custom_target(GMock)
-    # Upstream GTestConfig.cmake doesn't provide GTEST_LIBRARY but GTEST_LIBRARIES
-    # CMake 3.20+ uses the upstream gtest config if possible.
-    if (NOT DEFINED GTEST_LIBRARY)
-        set(GTEST_LIBRARY ${GTEST_LIBRARIES})
-    endif()
     string(REPLACE gtest gmock GMOCK_LIBRARY ${GTEST_LIBRARY})
 endif()
 


### PR DESCRIPTION
Previously, the GTEST_LIBRARY would only be set manually set when
GMock is not built from source, causing likage failures on systems
where Gmock is built from source and system-provided GTest does not
set it.

cc #205