### PR TITLE
Fix build when using GTest-1.11

### DIFF
--- a/tests/pointer_constraints.cpp
+++ b/tests/pointer_constraints.cpp
@@ -24,7 +24,11 @@
 
 #include <memory>
 
-using namespace testing;
+using testing::AnyNumber;
+using testing::Eq;
+using testing::Ne;
+using testing::NotNull;
+
 using namespace wlcs;
 
 namespace

--- a/tests/relative_pointer.cpp
+++ b/tests/relative_pointer.cpp
@@ -22,7 +22,11 @@
 
 #include <gmock/gmock.h>
 
-using namespace testing;
+using testing::AnyNumber;
+using testing::IsTrue;
+using testing::NotNull;
+using testing::_;
+
 using namespace wlcs;
 
 namespace


### PR DESCRIPTION
Some change in GTest 1.11 headers caused a conflict on the name
`Pointer`. Removing the unconditional import of namespace `testing`
in favor of individual imports of the used items fixes it.

cc #205