### PR TITLE
WlHandle: move specialization check to handle constructor

### DIFF
--- a/include/wl_handle.h
+++ b/include/wl_handle.h
@@ -39,6 +39,9 @@ public:
         : proxy{proxy},
           owns_wl_object{true}
     {
+        static_assert(
+            WlInterfaceDescriptor<T>::has_specialisation,
+            "Missing specialisation for WlInterfaceDescriptor");
         if (proxy == nullptr)
         {
             BOOST_THROW_EXCEPTION((std::logic_error{"Attempt to construct a WlHandle from null Wayland object"}));
@@ -92,9 +95,6 @@ private:
 template<typename WlType>
 auto wrap_wl_object(WlType* proxy) -> WlHandle<WlType>
 {
-    static_assert(
-        WlInterfaceDescriptor<WlType>::has_specialisation,
-        "Missing specialisation for WlInterfaceDescriptor");
     return WlHandle<WlType>{proxy};
 }
 


### PR DESCRIPTION
There are a number of ways one might end up with a `WlHandle` without using `wrap_wl_object()`. This makes sure the specialization check applies to all of them.