### PR TITLE
Test that text input is entered after child window is closed

### DIFF
--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -162,7 +162,8 @@ public:
 
     Surface(Surface&& other);
 
-    operator wl_surface*() const;
+    operator ::wl_surface*() const;
+    auto wl_surface() const -> ::wl_surface* { return *this; };
 
     void attach_buffer(int width, int height);
     void add_frame_callback(std::function<void(int)> const& on_frame);

--- a/include/xdg_shell_stable.h
+++ b/include/xdg_shell_stable.h
@@ -84,6 +84,7 @@ public:
     XdgPositionerStable(wlcs::Client& client);
     ~XdgPositionerStable();
     operator xdg_positioner*() const {return positioner;}
+    auto setup_default(std::pair<int, int> size) -> XdgPositionerStable&;
 
 private:
     xdg_positioner* const positioner;

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -1865,7 +1865,7 @@ public:
         wl_surface_destroy(surface_);
     }
 
-    wl_surface* surface() const
+    ::wl_surface* surface() const
     {
         return surface_;
     }
@@ -1940,7 +1940,7 @@ private:
         &frame_callback
     };
 
-    static void on_enter(void* data, wl_surface* /*wl_surface*/, wl_output* output)
+    static void on_enter(void* data, ::wl_surface* /*wl_surface*/, wl_output* output)
     {
         auto const self = static_cast<Impl*>(data);
 
@@ -1955,7 +1955,7 @@ private:
         }
     }
 
-    static void on_leave(void* data, wl_surface* /*wl_surface*/, wl_output* output)
+    static void on_leave(void* data, ::wl_surface* /*wl_surface*/, wl_output* output)
     {
         auto const self = static_cast<Impl*>(data);
 
@@ -1994,7 +1994,7 @@ wlcs::Surface::~Surface() = default;
 
 wlcs::Surface::Surface(Surface&&) = default;
 
-wlcs::Surface::operator wl_surface*() const
+wlcs::Surface::operator ::wl_surface*() const
 {
     return impl->surface();
 }

--- a/src/xdg_shell_stable.cpp
+++ b/src/xdg_shell_stable.cpp
@@ -112,8 +112,8 @@ auto wlcs::XdgPositionerStable::setup_default(std::pair<int, int> size) -> XdgPo
 {
     xdg_positioner_set_size(positioner, size.first, size.second);
     xdg_positioner_set_anchor_rect(positioner, 0, 0, 1, 1);
-    xdg_positioner_set_anchor(positioner, ZXDG_POSITIONER_V6_ANCHOR_TOP | ZXDG_POSITIONER_V6_ANCHOR_LEFT);
-    xdg_positioner_set_gravity(positioner, ZXDG_POSITIONER_V6_ANCHOR_BOTTOM | ZXDG_POSITIONER_V6_ANCHOR_RIGHT);
+    xdg_positioner_set_anchor(positioner, XDG_POSITIONER_ANCHOR_TOP_LEFT);
+    xdg_positioner_set_gravity(positioner, XDG_POSITIONER_ANCHOR_BOTTOM_RIGHT);
     return *this;
 }
 

--- a/src/xdg_shell_stable.cpp
+++ b/src/xdg_shell_stable.cpp
@@ -108,6 +108,15 @@ wlcs::XdgPositionerStable::~XdgPositionerStable()
     xdg_positioner_destroy(positioner);
 }
 
+auto wlcs::XdgPositionerStable::setup_default(std::pair<int, int> size) -> XdgPositionerStable&
+{
+    xdg_positioner_set_size(positioner, size.first, size.second);
+    xdg_positioner_set_anchor_rect(positioner, 0, 0, 1, 1);
+    xdg_positioner_set_anchor(positioner, ZXDG_POSITIONER_V6_ANCHOR_TOP | ZXDG_POSITIONER_V6_ANCHOR_LEFT);
+    xdg_positioner_set_gravity(positioner, ZXDG_POSITIONER_V6_ANCHOR_BOTTOM | ZXDG_POSITIONER_V6_ANCHOR_RIGHT);
+    return *this;
+}
+
 wlcs::XdgPopupStable::XdgPopupStable(
     XdgSurfaceStable& shell_surface_,
     std::optional<XdgSurfaceStable*> parent,

--- a/tests/text_input_v3_with_input_method_v2.cpp
+++ b/tests/text_input_v3_with_input_method_v2.cpp
@@ -243,8 +243,16 @@ TEST_F(TextInputV3WithInputMethodV2Test, text_input_enters_grabbing_popup)
     auto parent_xdg_surface = std::make_shared<wlcs::XdgSurfaceStable>(app_client, *parent_surface);
     auto parent_xdg_toplevel = std::make_shared<wlcs::XdgToplevelStable>(*parent_xdg_surface);
     parent_surface->attach_visible_buffer(20, 20);
+    the_server().move_surface_to(*parent_surface, 0, 0);
     app_client.roundtrip();
     Mock::VerifyAndClearExpectations(&text_input);
+
+    // This is needed to get a serial, which will be used later on
+    auto pointer = the_server().create_pointer();
+    pointer.move_to(2, 2);
+    pointer.left_click();
+    app_client.roundtrip();
+
     auto child_surface = std::make_unique<wlcs::Surface>(app_client);
     EXPECT_CALL(text_input, leave(parent_surface->operator wl_surface*()));
     EXPECT_CALL(text_input, enter(child_surface->operator wl_surface*()));

--- a/tests/text_input_v3_with_input_method_v2.cpp
+++ b/tests/text_input_v3_with_input_method_v2.cpp
@@ -228,7 +228,7 @@ TEST_F(TextInputV3WithInputMethodV2Test, text_input_does_not_enter_non_grabbing_
     EXPECT_CALL(text_input, leave(_)).Times(0);
     EXPECT_CALL(text_input, enter(_)).Times(0);
     auto child_xdg_surface = std::make_shared<wlcs::XdgSurfaceStable>(app_client, *child_surface);
-    auto child_xdg_toplevel = std::make_shared<wlcs::XdgPopupStable>(
+    auto child_xdg_popup = std::make_shared<wlcs::XdgPopupStable>(
         *child_xdg_surface,
         parent_xdg_surface.get(),
         wlcs::XdgPositionerStable{app_client}.setup_default({20, 20}));
@@ -238,6 +238,7 @@ TEST_F(TextInputV3WithInputMethodV2Test, text_input_does_not_enter_non_grabbing_
 
 TEST_F(TextInputV3WithInputMethodV2Test, text_input_enters_grabbing_popup)
 {
+    InSequence seq;
     auto parent_surface = std::make_unique<wlcs::Surface>(app_client);
     EXPECT_CALL(text_input, enter(parent_surface->wl_surface()));
     auto parent_xdg_surface = std::make_shared<wlcs::XdgSurfaceStable>(app_client, *parent_surface);
@@ -269,6 +270,7 @@ TEST_F(TextInputV3WithInputMethodV2Test, text_input_enters_grabbing_popup)
 /// Regression test for https://github.com/MirServer/mir/issues/2189
 TEST_F(TextInputV3WithInputMethodV2Test, text_input_enters_parent_surface_after_child_destroyed)
 {
+    InSequence seq;
     auto parent_surface = std::make_unique<wlcs::Surface>(app_client);
     EXPECT_CALL(text_input, enter(parent_surface->wl_surface()));
     auto parent_xdg_surface = std::make_shared<wlcs::XdgSurfaceStable>(app_client, *parent_surface);

--- a/tests/text_input_v3_with_input_method_v2.cpp
+++ b/tests/text_input_v3_with_input_method_v2.cpp
@@ -73,7 +73,7 @@ TEST_F(TextInputV3WithInputMethodV2Test, text_input_enters_surface_on_focus)
     EXPECT_CALL(text_input, enter(_))
         .WillOnce(SaveArg<0>(&entered));
     create_focussed_surface();
-    EXPECT_THAT(entered, Eq(app_surface.value().operator wl_surface*()));
+    EXPECT_THAT(entered, Eq(app_surface.value().wl_surface()));
 }
 
 TEST_F(TextInputV3WithInputMethodV2Test, text_input_leaves_surface_on_unfocus)
@@ -81,7 +81,7 @@ TEST_F(TextInputV3WithInputMethodV2Test, text_input_leaves_surface_on_unfocus)
     create_focussed_surface();
     // Text input will not .enter() other surface because it belongs to a different client
     EXPECT_CALL(text_input, enter(_)).Times(0);
-    EXPECT_CALL(text_input, leave(app_surface.value().operator wl_surface*()));
+    EXPECT_CALL(text_input, leave(app_surface.value().wl_surface()));
 
     // Create a 2nd client with a focused surface
     wlcs::Client other_client{the_server()};
@@ -218,7 +218,7 @@ TEST_F(TextInputV3WithInputMethodV2Test, input_method_can_send_preedit)
 TEST_F(TextInputV3WithInputMethodV2Test, text_input_does_not_enter_non_grabbing_popup)
 {
     auto parent_surface = std::make_unique<wlcs::Surface>(app_client);
-    EXPECT_CALL(text_input, enter(parent_surface->operator wl_surface*()));
+    EXPECT_CALL(text_input, enter(parent_surface->wl_surface()));
     auto parent_xdg_surface = std::make_shared<wlcs::XdgSurfaceStable>(app_client, *parent_surface);
     auto parent_xdg_toplevel = std::make_shared<wlcs::XdgToplevelStable>(*parent_xdg_surface);
     parent_surface->attach_visible_buffer(20, 20);
@@ -239,7 +239,7 @@ TEST_F(TextInputV3WithInputMethodV2Test, text_input_does_not_enter_non_grabbing_
 TEST_F(TextInputV3WithInputMethodV2Test, text_input_enters_grabbing_popup)
 {
     auto parent_surface = std::make_unique<wlcs::Surface>(app_client);
-    EXPECT_CALL(text_input, enter(parent_surface->operator wl_surface*()));
+    EXPECT_CALL(text_input, enter(parent_surface->wl_surface()));
     auto parent_xdg_surface = std::make_shared<wlcs::XdgSurfaceStable>(app_client, *parent_surface);
     auto parent_xdg_toplevel = std::make_shared<wlcs::XdgToplevelStable>(*parent_xdg_surface);
     parent_surface->attach_visible_buffer(20, 20);
@@ -254,8 +254,8 @@ TEST_F(TextInputV3WithInputMethodV2Test, text_input_enters_grabbing_popup)
     app_client.roundtrip();
 
     auto child_surface = std::make_unique<wlcs::Surface>(app_client);
-    EXPECT_CALL(text_input, leave(parent_surface->operator wl_surface*()));
-    EXPECT_CALL(text_input, enter(child_surface->operator wl_surface*()));
+    EXPECT_CALL(text_input, leave(parent_surface->wl_surface()));
+    EXPECT_CALL(text_input, enter(child_surface->wl_surface()));
     auto child_xdg_surface = std::make_shared<wlcs::XdgSurfaceStable>(app_client, *child_surface);
     auto child_xdg_popup = std::make_shared<wlcs::XdgPopupStable>(
         *child_xdg_surface,
@@ -270,7 +270,7 @@ TEST_F(TextInputV3WithInputMethodV2Test, text_input_enters_grabbing_popup)
 TEST_F(TextInputV3WithInputMethodV2Test, text_input_enters_parent_surface_after_child_destroyed)
 {
     auto parent_surface = std::make_unique<wlcs::Surface>(app_client);
-    EXPECT_CALL(text_input, enter(parent_surface->operator wl_surface*()));
+    EXPECT_CALL(text_input, enter(parent_surface->wl_surface()));
     auto parent_xdg_surface = std::make_shared<wlcs::XdgSurfaceStable>(app_client, *parent_surface);
     auto parent_xdg_toplevel = std::make_shared<wlcs::XdgToplevelStable>(*parent_xdg_surface);
     parent_surface->attach_visible_buffer(20, 20);
@@ -279,8 +279,8 @@ TEST_F(TextInputV3WithInputMethodV2Test, text_input_enters_parent_surface_after_
 
     {
         auto child_surface = std::make_unique<wlcs::Surface>(app_client);
-        EXPECT_CALL(text_input, leave(parent_surface->operator wl_surface*()));
-        EXPECT_CALL(text_input, enter(child_surface->operator wl_surface*()));
+        EXPECT_CALL(text_input, leave(parent_surface->wl_surface()));
+        EXPECT_CALL(text_input, enter(child_surface->wl_surface()));
         auto child_xdg_surface = std::make_shared<wlcs::XdgSurfaceStable>(app_client, *child_surface);
         auto child_xdg_toplevel = std::make_shared<wlcs::XdgToplevelStable>(*child_xdg_surface);
         xdg_toplevel_set_parent(*child_xdg_toplevel, *parent_xdg_toplevel);
@@ -289,7 +289,7 @@ TEST_F(TextInputV3WithInputMethodV2Test, text_input_enters_parent_surface_after_
         Mock::VerifyAndClearExpectations(&text_input);
 
         EXPECT_CALL(text_input, leave(nullptr)); // Child surface will be destroyed by the time the message comes in
-        EXPECT_CALL(text_input, enter(parent_surface->operator wl_surface*()));
+        EXPECT_CALL(text_input, enter(parent_surface->wl_surface()));
     }
 
     app_client.roundtrip();

--- a/tests/text_input_v3_with_input_method_v2.cpp
+++ b/tests/text_input_v3_with_input_method_v2.cpp
@@ -232,6 +232,7 @@ TEST_F(TextInputV3WithInputMethodV2Test, text_input_enters_parent_surface_after_
         EXPECT_CALL(text_input, enter(child_surface->operator wl_surface*()));
         auto child_xdg_surface = std::make_shared<wlcs::XdgSurfaceStable>(app_client, *child_surface);
         auto child_xdg_toplevel = std::make_shared<wlcs::XdgToplevelStable>(*child_xdg_surface);
+        xdg_toplevel_set_parent(*child_xdg_toplevel, *parent_xdg_toplevel);
         child_surface->attach_visible_buffer(20, 20);
         app_client.roundtrip();
         Mock::VerifyAndClearExpectations(&text_input);

--- a/tests/text_input_v3_with_input_method_v2.cpp
+++ b/tests/text_input_v3_with_input_method_v2.cpp
@@ -225,8 +225,8 @@ TEST_F(TextInputV3WithInputMethodV2Test, text_input_does_not_enter_non_grabbing_
     app_client.roundtrip();
     Mock::VerifyAndClearExpectations(&text_input);
     auto child_surface = std::make_unique<wlcs::Surface>(app_client);
-    EXPECT_CALL(text_input, leave(parent_surface->operator wl_surface*())).Times(0);
-    EXPECT_CALL(text_input, enter(child_surface->operator wl_surface*())).Times(0);
+    EXPECT_CALL(text_input, leave(_)).Times(0);
+    EXPECT_CALL(text_input, enter(_)).Times(0);
     auto child_xdg_surface = std::make_shared<wlcs::XdgSurfaceStable>(app_client, *child_surface);
     auto child_xdg_toplevel = std::make_shared<wlcs::XdgPopupStable>(
         *child_xdg_surface,

--- a/tests/wlr_virtual_pointer_v1.cpp
+++ b/tests/wlr_virtual_pointer_v1.cpp
@@ -90,7 +90,7 @@ public:
           listener{receive_client.seat()},
           manager{send_client.bind_if_supported<zwlr_virtual_pointer_manager_v1>(wlcs::AnyVersion)}
     {
-        EXPECT_CALL(listener, enter(_, surface.operator wl_surface*(), _, _));
+        EXPECT_CALL(listener, enter(_, surface.wl_surface(), _, _));
         EXPECT_CALL(listener, motion(_, _, _)).Times(AnyNumber());
         EXPECT_CALL(listener, frame()).Times(AnyNumber());
         the_server().move_surface_to(surface, 0, 0);


### PR DESCRIPTION
This is supposed to test https://github.com/MirServer/mir/issues/2189, but it passes for some reason. A problem for next week.