### PR TITLE
Support compositors that do not implement wl_shell

### DIFF
--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -768,6 +768,26 @@ public:
         return surface;
     }
 
+    Surface create_visible_surface(Client& client, int width, int height)
+    {
+        if (shell)
+        {
+            return create_wl_shell_surface(client, width, height);
+        }
+        else if (xdg_shell_stable)
+        {
+            return create_xdg_shell_stable_surface(client, width, height);
+        }
+        else if (xdg_shell_v6)
+        {
+            return create_xdg_shell_v6_surface(client, width, height);
+        }
+        else
+        {
+            throw std::runtime_error("compositor does not support any known shell protocols");
+        }
+    }
+
     wl_shell* the_shell() const
     {
         if (shell)
@@ -1649,7 +1669,7 @@ wlcs::Surface wlcs::Client::create_xdg_shell_stable_surface(int width, int heigh
 
 wlcs::Surface wlcs::Client::create_visible_surface(int width, int height)
 {
-    return impl->create_wl_shell_surface(*this, width, height);
+    return impl->create_visible_surface(*this, width, height);
 }
 
 size_t wlcs::Client::output_count() const

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -714,7 +714,7 @@ public:
     {
         Surface surface{client};
 
-        wl_shell_surface * shell_surface = wl_shell_get_shell_surface(shell, surface);
+        wl_shell_surface * shell_surface = wl_shell_get_shell_surface(the_shell(), surface);
         surface.run_on_destruction([shell_surface]()
             {
                 wl_shell_surface_destroy(shell_surface);
@@ -770,7 +770,21 @@ public:
 
     wl_shell* the_shell() const
     {
-        return shell;
+        if (shell)
+        {
+            return shell;
+        }
+        else
+        {
+            if (!supported_extensions || !supported_extensions->count("wl_shell"))
+            {
+                BOOST_THROW_EXCEPTION((ExtensionExpectedlyNotSupported{"wl_shell", AnyVersion}));
+            }
+            else
+            {
+                throw std::runtime_error("Failed to bind to wl_shell");
+            }
+        }
     }
 
     zxdg_shell_v6* the_xdg_shell_v6() const

--- a/tests/frame_submission.cpp
+++ b/tests/frame_submission.cpp
@@ -30,7 +30,7 @@ namespace
 struct FrameSubmission : StartedInProcessServer
 {
     Client client{the_server()};
-    Surface surface{client};
+    Surface surface{client.create_visible_surface(200, 200)};
 
     void submit_frame(bool& frame_consumed);
 
@@ -63,12 +63,6 @@ void FrameSubmission::wait_for_frame(bool const& consumed_flag)
 
 TEST_F(FrameSubmission, post_one_frame_at_a_time)
 {
-    ShmBuffer buffer{client, 200, 200};
-    wl_surface_attach(surface, buffer, 0, 0);
-
-    auto shell_surface = wl_shell_get_shell_surface(client.shell(), surface);
-    wl_shell_surface_set_toplevel(shell_surface);
-
     for (auto i = 0; i != 10; ++i)
     {
         auto frame_consumed = false;


### PR DESCRIPTION
This makes WLCS expect-fail tests that depend on `wl_shell` if the compositor does not claim to support it, and removes the dependency on `wl_shell` from all tests that do not require it. It should not change behavior on shells that do support `wl_shell`. Fixes #218.