### PR TITLE
Do not bind to interface versions newer than supported

### DIFF
--- a/include/version_specifier.h
+++ b/include/version_specifier.h
@@ -20,7 +20,8 @@
 #define WLCS_VERSION_SPECIFIER_H_
 
 #include <cstdint>
-#include <experimental/optional>
+#include <optional>
+#include <string>
 
 namespace wlcs
 {
@@ -30,7 +31,7 @@ public:
     VersionSpecifier() = default;
     virtual ~VersionSpecifier() = default;
 
-    virtual auto select_version(uint32_t max_version) const -> std::experimental::optional<uint32_t> = 0;
+    virtual auto select_version(uint32_t max_version) const -> std::optional<uint32_t> = 0;
     virtual auto describe() const -> std::string = 0;
 };
 
@@ -39,7 +40,7 @@ class ExactlyVersion : public VersionSpecifier
 public:
     explicit ExactlyVersion(uint32_t version) noexcept;
 
-    auto select_version(uint32_t max_version) const -> std::experimental::optional<uint32_t> override;
+    auto select_version(uint32_t max_version) const -> std::optional<uint32_t> override;
     auto describe() const -> std::string override;
 private:
     uint32_t const version;
@@ -50,7 +51,7 @@ class AtLeastVersion : public VersionSpecifier
 public:
     explicit AtLeastVersion(uint32_t version) noexcept;
 
-    auto select_version(uint32_t max_version) const -> std::experimental::optional<uint32_t> override;
+    auto select_version(uint32_t max_version) const -> std::optional<uint32_t> override;
     auto describe() const -> std::string override;
 private:
     uint32_t const version;

--- a/include/version_specifier.h
+++ b/include/version_specifier.h
@@ -31,7 +31,9 @@ public:
     VersionSpecifier() = default;
     virtual ~VersionSpecifier() = default;
 
-    virtual auto select_version(uint32_t max_version) const -> std::optional<uint32_t> = 0;
+    virtual auto select_version(
+        uint32_t max_available_version,
+        uint32_t max_supported_version) const -> std::optional<uint32_t> = 0;
     virtual auto describe() const -> std::string = 0;
 };
 
@@ -40,7 +42,9 @@ class ExactlyVersion : public VersionSpecifier
 public:
     explicit ExactlyVersion(uint32_t version) noexcept;
 
-    auto select_version(uint32_t max_version) const -> std::optional<uint32_t> override;
+    auto select_version(
+        uint32_t max_available_version,
+        uint32_t max_supported_version) const -> std::optional<uint32_t> override;
     auto describe() const -> std::string override;
 private:
     uint32_t const version;
@@ -51,7 +55,9 @@ class AtLeastVersion : public VersionSpecifier
 public:
     explicit AtLeastVersion(uint32_t version) noexcept;
 
-    auto select_version(uint32_t max_version) const -> std::optional<uint32_t> override;
+    auto select_version(
+        uint32_t max_available_version,
+        uint32_t max_supported_version) const -> std::optional<uint32_t> override;
     auto describe() const -> std::string override;
 private:
     uint32_t const version;

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -909,7 +909,7 @@ public:
         {
             expected_to_be_supported =
                 supported_extensions->count(to_bind.name) &&
-                version.select_version(supported_extensions->at(to_bind.name));
+                version.select_version(supported_extensions->at(to_bind.name), to_bind.version);
         }
 
         /* TODO: Mark tests using globals which exist, but are listed as unsupported as
@@ -920,7 +920,7 @@ public:
         auto const global = globals.find(to_bind.name);
         if (global != globals.end())
         {
-            auto const version_to_bind = version.select_version(global->second.version);
+            auto const version_to_bind = version.select_version(global->second.version, to_bind.version);
             if (version_to_bind)
             {
                 auto global_proxy = wl_registry_bind(registry, global->second.id, &to_bind, version_to_bind.value());

--- a/src/version_specifier.cpp
+++ b/src/version_specifier.cpp
@@ -17,19 +17,35 @@
  */
 
 #include "version_specifier.h"
+#include "boost/throw_exception.hpp"
+#include <stdexcept>
 
 wlcs::ExactlyVersion::ExactlyVersion(uint32_t version) noexcept
     : version{version}
 {
 }
 
-auto wlcs::ExactlyVersion::select_version(uint32_t max_version) const -> std::optional<uint32_t>
+auto wlcs::ExactlyVersion::select_version(
+    uint32_t max_available_version,
+    uint32_t max_supported_version) const -> std::optional<uint32_t>
 {
-    if (max_version < version)
+    if (version > max_supported_version)
+    {
+        BOOST_THROW_EXCEPTION(std::logic_error(
+            "Required version " +
+            std::to_string(version) +
+            " is higher than the highest version supported by WLCS (" +
+            std::to_string(max_supported_version) +
+            ")"));
+    }
+    else if (version > max_available_version)
     {
         return {};
     }
-    return {version};
+    else
+    {
+        return {version};
+    }
 }
 
 auto wlcs::ExactlyVersion::describe() const -> std::string
@@ -42,13 +58,27 @@ wlcs::AtLeastVersion::AtLeastVersion(uint32_t version) noexcept
 {
 }
 
-auto wlcs::AtLeastVersion::select_version(uint32_t max_version) const -> std::optional<uint32_t>
+auto wlcs::AtLeastVersion::select_version(
+    uint32_t max_available_version,
+    uint32_t max_supported_version) const -> std::optional<uint32_t>
 {
-    if (max_version < version)
+    if (version > max_supported_version)
+    {
+        BOOST_THROW_EXCEPTION(std::logic_error(
+            "Required version " +
+            std::to_string(version) +
+            " is higher than the highest version supported by WLCS (" +
+            std::to_string(max_supported_version) +
+            ")"));
+    }
+    else if (version > max_available_version)
     {
         return {};
     }
-    return {max_version};
+    else
+    {
+        return {std::min(max_available_version, max_supported_version)};
+    }
 }
 
 auto wlcs::AtLeastVersion::describe() const -> std::string

--- a/src/version_specifier.cpp
+++ b/src/version_specifier.cpp
@@ -18,14 +18,12 @@
 
 #include "version_specifier.h"
 
-using std::experimental::optional;
-
 wlcs::ExactlyVersion::ExactlyVersion(uint32_t version) noexcept
     : version{version}
 {
 }
 
-auto wlcs::ExactlyVersion::select_version(uint32_t max_version) const -> optional<uint32_t>
+auto wlcs::ExactlyVersion::select_version(uint32_t max_version) const -> std::optional<uint32_t>
 {
     if (max_version < version)
     {
@@ -44,7 +42,7 @@ wlcs::AtLeastVersion::AtLeastVersion(uint32_t version) noexcept
 {
 }
 
-auto wlcs::AtLeastVersion::select_version(uint32_t max_version) const -> optional<uint32_t>
+auto wlcs::AtLeastVersion::select_version(uint32_t max_version) const -> std::optional<uint32_t>
 {
     if (max_version < version)
     {


### PR DESCRIPTION
Fixes #234 