### PR TITLE
Make zxdg_shell_v6 ExpectedlyNotSupported if not in supported_extensions

### DIFF
--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -809,7 +809,21 @@ public:
 
     zxdg_shell_v6* the_xdg_shell_v6() const
     {
-        return xdg_shell_v6;
+        if (xdg_shell_v6)
+        {
+            return xdg_shell_v6;
+        }
+        else
+        {
+            if (!supported_extensions || !supported_extensions->count("zxdg_shell_v6"))
+            {
+                BOOST_THROW_EXCEPTION((ExtensionExpectedlyNotSupported{"zxdg_shell_v6", AnyVersion}));
+            }
+            else
+            {
+                throw std::runtime_error("Failed to bind to zxdg_shell_v6");
+            }
+        }
     }
 
     xdg_wm_base* the_xdg_shell_stable() const


### PR DESCRIPTION
I have tested that it does indeed causes GTest to skip the related tests.

Fixes #237 