### PR TITLE
Destroy xdg_toplevel before xdg_surface on cleanup

### DIFF
--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -737,8 +737,8 @@ public:
 
         surface.run_on_destruction([xdg_surface, xdg_toplevel]() mutable
             {
-                xdg_surface.reset();
                 xdg_toplevel.reset();
+                xdg_surface.reset();
             });
 
         wl_surface_commit(surface);
@@ -757,8 +757,8 @@ public:
 
         surface.run_on_destruction([xdg_surface, xdg_toplevel]() mutable
             {
-                xdg_surface.reset();
                 xdg_toplevel.reset();
+                xdg_surface.reset();
             });
 
         wl_surface_commit(surface);


### PR DESCRIPTION
This is mandated by the protocol.