### PR TITLE
Create surface in primary selection tests

### DIFF
--- a/tests/primary_selection.cpp
+++ b/tests/primary_selection.cpp
@@ -68,6 +68,7 @@ struct PrimarySelection : StartedInProcessServer
 {
     SourceApp   source_app{the_server()};
     SinkApp     sink_app{the_server()};
+    Surface     surface{sink_app.create_visible_surface(10, 10)};
 
     void TearDown() override
     {


### PR DESCRIPTION
Mir's primary selection implementation will not allow clients to paste when they do not have focus, so the tests fail without this.