### PR TITLE
spread: use spread-mir-ci

### DIFF
--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Set up Spread
       run: |
         set -euo pipefail 
-        sudo snap install spread-mir-ci --beta
+        sudo snap install spread-mir-ci
         sudo snap run lxd init --auto
 
     - name: Check out code

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -45,10 +45,8 @@ jobs:
     - name: Set up Spread
       run: |
         set -euo pipefail 
-        curl -s -O https://people.canonical.com/~chrishr/spread.snap
+        sudo snap install spread-mir-ci --beta
         sudo snap run lxd init --auto
-        sudo snap install --dangerous spread.snap
-        sudo snap connect spread:lxd lxd:lxd
 
     - name: Check out code
       uses: actions/checkout@v3
@@ -56,4 +54,4 @@ jobs:
     - name: Run Spread task
       env:
         LXD_DIR: /var/snap/lxd/common/lxd
-      run: sg lxd -c 'snap run spread -v ${{ matrix.spread-task }}'
+      run: sg lxd -c 'snap run spread-mir-ci.spread -v ${{ matrix.spread-task }}'

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -1541,7 +1541,7 @@ private:
             auto wl_output = static_cast<struct wl_output*>(safe_bind(registry, id, &wl_output_interface, version));
             auto output = std::make_unique<Output>(wl_output);
             wl_output_add_listener(wl_output, &Output::listener, output.get());
-            me->outputs.push_back(move(output));
+            me->outputs.push_back(std::move(output));
 
             // Ensure we receive the initial output events.
             me->server_roundtrip();


### PR DESCRIPTION
We're maintaining a spread fork there.

---

Rather than #250. The snap has MirServer/spread-mir-ci#2, fixing the issue.