### PR TITLE
Fix BadBufferTest.test_truncated_shm_file

### DIFF
--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -299,35 +299,12 @@ private:
 class ProtocolError : public std::system_error
 {
 public:
-    ProtocolError(wl_interface const* interface, uint32_t code)
-        : std::system_error(EPROTO, std::system_category(), "Wayland protocol error"),
-        interface_{interface},
-        code_{code},
-        message{
-            std::string{"Wayland protocol error: "} +
-            std::to_string(code) +
-            " on interface " +
-            interface_->name +
-            " v" +
-            std::to_string(interface->version)}
-    {
-    }
+    ProtocolError(wl_interface const* interface, uint32_t code);
 
-    char const* what() const noexcept override
-    {
-        return message.c_str();
-    }
+    char const* what() const noexcept override;
 
-    uint32_t error_code() const
-    {
-        return code_;
-    }
-
-    wl_interface const* interface() const
-    {
-        return interface_;
-    }
-
+    uint32_t error_code() const;
+    wl_interface const* interface() const;
 private:
     wl_interface const* const interface_;
     uint32_t const code_;

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -56,6 +56,35 @@ public:
     }
 };
 
+wlcs::ProtocolError::ProtocolError(wl_interface const* interface, uint32_t code)
+    : std::system_error(EPROTO, std::system_category(), "Wayland protocol error"),
+      interface_{interface},
+      code_{code},
+      message{
+          std::string{"Wayland protocol error: "} +
+          std::to_string(code) +
+          " on interface " +
+          interface_->name +
+          " v" +
+          std::to_string(interface->version)}
+    {
+    }
+
+char const* wlcs::ProtocolError::what() const noexcept
+{
+    return message.c_str();
+}
+
+uint32_t wlcs::ProtocolError::error_code() const
+{
+    return code_;
+}
+
+wl_interface const* wlcs::ProtocolError::interface() const
+{
+    return interface_;
+}
+
 wlcs::ExtensionExpectedlyNotSupported::ExtensionExpectedlyNotSupported(char const* extension, VersionSpecifier const& version)
     : std::runtime_error{
         std::string{"Extension: "} +

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -56,6 +56,18 @@ public:
     }
 };
 
+namespace
+{
+auto interface_description_if_valid(wl_interface const* interface) -> std::string
+{
+    if (interface)
+    {
+        using namespace std::literals::string_literals;
+        return interface->name + " v"s + std::to_string(interface->version);
+    }
+    return "<UNKNOWN INTERFACE>";
+}
+}
 wlcs::ProtocolError::ProtocolError(wl_interface const* interface, uint32_t code)
     : std::system_error(EPROTO, std::system_category(), "Wayland protocol error"),
       interface_{interface},
@@ -63,10 +75,7 @@ wlcs::ProtocolError::ProtocolError(wl_interface const* interface, uint32_t code)
       message{
           std::string{"Wayland protocol error: "} +
           std::to_string(code) +
-          " on interface " +
-          interface_->name +
-          " v" +
-          std::to_string(interface->version)}
+          " on interface " + interface_description_if_valid(interface)}
     {
     }
 


### PR DESCRIPTION
The protocol error should be generated on the `wl_shm_pool`,
as that's the object that has been asked for an invalid operation.

Additionally, fix the assumption that `wl_display_get_protocol_error`
will fill in the `interface` parameter. In the case where the server
sends an error on an object the client has already deleted, the
`interface` parameter will be set to null.