### PR TITLE
GitHub: Fix actions for master→main rename

### DIFF
--- a/.github/workflows/ppa-upload.yml
+++ b/.github/workflows/ppa-upload.yml
@@ -3,7 +3,7 @@ name: PPA Upload
 on:
   push:
     branches:
-    - master
+    - main
     - release/[0-9]+.[0-9]+
     tags:
     - v[0-9]+[0-9]+.[0-9]+

--- a/.github/workflows/spread.yml
+++ b/.github/workflows/spread.yml
@@ -3,7 +3,7 @@ name: Spread
 on:
   push:
     branches:
-    - master
+    - main
     - staging
     - trying
     - release/[0-9]+.[0-9]+


### PR DESCRIPTION
When we renamed the `master` branch to `main` we neglected to update the github actions.

Make this update, so that merging wlcs PRs will again result in packages being published to the PPA.