### PR TITLE
test

### DIFF
--- a/tests/wlr_layer_shell_v1.cpp
+++ b/tests/wlr_layer_shell_v1.cpp
@@ -41,6 +41,11 @@ public:
     {
     }
 
+    ~LayerSurfaceTest()
+    {
+        client.roundtrip();
+    }
+
     void commit_and_wait_for_configure()
     {
         wl_surface_commit(surface);


### PR DESCRIPTION
https://github.com/MirServer/mir/issues/2748 just might be a teardown synchronization problem. This adds a bit of sync that we see in some other tests