### PR TITLE
Fix CMake install dir usage in pkgconfig, honour CMAKE_INSTALL_INCLUDEDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,7 +278,7 @@ install(
 
 install(
   DIRECTORY include/wlcs
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/include/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
 configure_file(

--- a/wlcs.pc.in
+++ b/wlcs.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_FULL_BINDIR@
 libexecdir=@CMAKE_INSTALL_FULL_LIBEXECDIR@
-includedir=${prefix}/include
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 test_runner=${libexecdir}/wlcs/wlcs
 

--- a/wlcs.pc.in
+++ b/wlcs.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}/@CMAKE_INSTALL_BINDIR@
-libexecdir=${prefix}/@CMAKE_INSTALL_LIBEXECDIR@
+exec_prefix=@CMAKE_INSTALL_FULL_BINDIR@
+libexecdir=@CMAKE_INSTALL_FULL_LIBEXECDIR@
 includedir=${prefix}/include
 
 test_runner=${libexecdir}/wlcs/wlcs


### PR DESCRIPTION
1. Current assumption about `CMAKE_INSTALL_<dir>` being relative to `CMAKE_INSTALL_PREFIX` is wrong.

```
Broken paths found in a .pc file! /nix/store/0lfs3w5mgjh5rdlrzwm4h18g2jpmmygx-wlcs-1.4.0/lib/pkgconfig/wlcs.pc
The following lines have issues (specifically '//' in paths).
2:exec_prefix=${prefix}//nix/store/0lfs3w5mgjh5rdlrzwm4h18g2jpmmygx-wlcs-1.4.0/bin
3:libexecdir=${prefix}//nix/store/0lfs3w5mgjh5rdlrzwm4h18g2jpmmygx-wlcs-1.4.0/libexec
It is very likely that paths are being joined improperly.
ex: "${prefix}/@CMAKE_INSTALL_LIBDIR@" should be "@CMAKE_INSTALL_FULL_LIBDIR@"
Please see https://github.com/NixOS/nixpkgs/issues/144170 for more details.
```

`CMAKE_INSTALL_<dir>` must not be assumed to be relative to `CMAKE_INSTALL_PREFIX`, [according to the CMake documentation](https://cmake.org/cmake/help/v3.25/module/GNUInstallDirs.html?highlight=gnuinstalldirs):

> It should typically be a path relative to the installation prefix so that it can be converted to an absolute path in a relocatable way (see `CMAKE_INSTALL_FULL_<dir>`). **However, an absolute path is also allowed.**

CMake has special `_FULL_` variants of the variables which apply the prefix when needed:

> The absolute path generated from the corresponding `CMAKE_INSTALL_<dir>` value. If the value is not already an absolute path, an absolute path is constructed typically by prepending the value of the [`CMAKE_INSTALL_PREFIX`](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html#variable:CMAKE_INSTALL_PREFIX) variable.

---

2. `CMAKE_INSTALL_INCLUDEDIR` isn't honoured.

CMake has `CMAKE_INSTALL_INCLUDEDIR` for specifying where header files shall be installed to. It defaults to `include` (relative to `CMAKE_INSTALL_PREFIX`) so when not specifying an include dir, this is functionally identical to the current hardcoding.