### PR TITLE
pkgconfig: Use better path concatenation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,10 @@ install(
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
+include(JoinPaths)
+join_paths(PKGCONFIG_BINDIR "\${prefix}" "${CMAKE_INSTALL_BINDIR}")
+join_paths(PKGCONFIG_LIBEXECDIR "\${prefix}" "${CMAKE_INSTALL_LIBEXECDIR}")
+join_paths(PKGCONFIG_INCLUDEDIR "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
 configure_file(
   wlcs.pc.in
   ${CMAKE_CURRENT_BINARY_DIR}/wlcs.pc

--- a/cmake/JoinPaths.cmake
+++ b/cmake/JoinPaths.cmake
@@ -1,0 +1,23 @@
+# This module provides function for joining paths
+# known from most languages
+#
+# SPDX-License-Identifier: (MIT OR CC0-1.0)
+# Copyright 2020 Jan Tojnar
+# https://github.com/jtojnar/cmake-snips
+#
+# Modelled after Python’s os.path.join
+# https://docs.python.org/3.7/library/os.path.html#os.path.join
+# Windows not supported
+function(join_paths joined_path first_path_segment)
+    set(temp_path "${first_path_segment}")
+    foreach(current_segment IN LISTS ARGN)
+        if(NOT ("${current_segment}" STREQUAL ""))
+            if(IS_ABSOLUTE "${current_segment}")
+                set(temp_path "${current_segment}")
+            else()
+                set(temp_path "${temp_path}/${current_segment}")
+            endif()
+        endif()
+    endforeach()
+    set(${joined_path} "${temp_path}" PARENT_SCOPE)
+endfunction()

--- a/wlcs.pc.in
+++ b/wlcs.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_FULL_BINDIR@
-libexecdir=@CMAKE_INSTALL_FULL_LIBEXECDIR@
-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+exec_prefix=@PKGCONFIG_BINDIR@
+libexecdir=@PKGCONFIG_LIBEXECDIR@
+includedir=@PKGCONFIG_INCLUDEDIR@
 
 test_runner=${libexecdir}/wlcs/wlcs
 


### PR DESCRIPTION
A correction to #258, based on recommendations from [jtojnar/cmake-snips#concatenating-paths-when-building-pkg-config-files](https://github.com/jtojnar/cmake-snips/tree/a9d72829ab0cb42e541c9975e698d6b8282610ed#concatenating-paths-when-building-pkg-config-files).

Unconditionally using `CMAKE_INSTALL_FULL_*DIR`s in a pkg-config file is slightly wrong, because it is expected that the variables are made up of other variables, all of which can be overridden by the user.

CMake added a `cmake_path` function which can do the required concatenation without the added function, but it's only available on version 3.20 while the current CMakeLists specifies a minimum version of 3.5.

I've checked that this gives regular `${prefix}/<dir>` entries again when the `CMAKE_INSTALL_*DIR`s are relative, and the `CMAKE_INSTALL_*DIR`s verbatim when they are absolute.