### PR TITLE
XDG stable: use mock methods instead of notification lists

### DIFF
--- a/include/xdg_shell_stable.h
+++ b/include/xdg_shell_stable.h
@@ -24,6 +24,8 @@
 #include "wl_interface_descriptor.h"
 #include "wl_handle.h"
 
+#include <gmock/gmock.h>
+
 namespace wlcs
 {
 WLCS_CREATE_INTERFACE_DESCRIPTOR(xdg_wm_base)
@@ -36,24 +38,11 @@ public:
     XdgSurfaceStable& operator=(XdgSurfaceStable const&) = delete;
     ~XdgSurfaceStable();
 
-    void add_configure_notification(std::function<void(uint32_t)> notification)
-    {
-        configure_notifiers.push_back(notification);
-    }
+    MOCK_METHOD(void, configure, (uint32_t serial));
 
     operator xdg_surface*() const {return shell_surface;}
 
-    std::vector<std::function<void(uint32_t)>> configure_notifiers;
-
 private:
-    static void configure_thunk(void *data, struct xdg_surface *, uint32_t serial)
-    {
-        for (auto& notifier : static_cast<XdgSurfaceStable*>(data)->configure_notifiers)
-        {
-            notifier(serial);
-        }
-    }
-
     xdg_surface* shell_surface;
 };
 
@@ -78,41 +67,13 @@ public:
     XdgToplevelStable& operator=(XdgToplevelStable const&) = delete;
     ~XdgToplevelStable();
 
-    void add_configure_notification(std::function<void(int32_t, int32_t, struct wl_array *)> notification)
-    {
-        configure_notifiers.push_back(notification);
-    }
-
-    void add_close_notification(std::function<void()> notification)
-    {
-        close_notifiers.push_back(notification);
-    }
+    MOCK_METHOD(void, configure, (int32_t width, int32_t height, wl_array* states));
+    MOCK_METHOD(void, close, ());
 
     operator xdg_toplevel*() const {return toplevel;}
 
     XdgSurfaceStable* const shell_surface;
     xdg_toplevel* toplevel;
-
-    std::vector<std::function<void(int32_t, int32_t, struct wl_array *)>> configure_notifiers;
-    std::vector<std::function<void()>> close_notifiers;
-
-private:
-    static void configure_thunk(void *data, struct xdg_toplevel *, int32_t width, int32_t height,
-                                struct wl_array *states)
-    {
-        for (auto& notifier : static_cast<XdgToplevelStable*>(data)->configure_notifiers)
-        {
-            notifier(width, height, states);
-        }
-    }
-
-    static void close_thunk(void *data, struct xdg_toplevel *)
-    {
-        for (auto& notifier : static_cast<XdgToplevelStable*>(data)->close_notifiers)
-        {
-            notifier();
-        }
-    }
 };
 
 class XdgPositionerStable
@@ -137,15 +98,8 @@ public:
     XdgPopupStable& operator=(XdgPopupStable const&) = delete;
     ~XdgPopupStable();
 
-    void add_configure_notification(std::function<void(int32_t, int32_t, int32_t, int32_t)> notification)
-    {
-        configure_notifiers.push_back(notification);
-    }
-
-    void add_close_notification(std::function<void()> notification)
-    {
-        popup_done_notifiers.push_back(notification);
-    }
+    MOCK_METHOD(void, configure, (int32_t x, int32_t y, int32_t width, int32_t height));
+    MOCK_METHOD(void, done, ());
 
     operator xdg_popup*() const {return popup;}
 
@@ -154,24 +108,6 @@ public:
 
     std::vector<std::function<void(int32_t, int32_t, int32_t, int32_t)>> configure_notifiers;
     std::vector<std::function<void()>> popup_done_notifiers;
-
-private:
-    static void configure_thunk(void* data, struct xdg_popup*, int32_t x, int32_t y,
-                                int32_t width, int32_t height)
-    {
-        for (auto& notifier : static_cast<XdgPopupStable*>(data)->configure_notifiers)
-        {
-            notifier(x, y, width, height);
-        }
-    }
-
-    static void popup_done_thunk(void *data, struct xdg_popup*)
-    {
-        for (auto& notifier : static_cast<XdgPopupStable*>(data)->popup_done_notifiers)
-        {
-            notifier();
-        }
-    }
 };
 
 }

--- a/include/xdg_shell_v6.h
+++ b/include/xdg_shell_v6.h
@@ -22,6 +22,8 @@
 #include "in_process_server.h"
 #include "generated/xdg-shell-unstable-v6-client.h"
 
+#include <gmock/gmock.h>
+
 namespace wlcs
 {
 
@@ -33,24 +35,11 @@ public:
     XdgSurfaceV6& operator=(XdgSurfaceV6 const&) = delete;
     ~XdgSurfaceV6();
 
-    void add_configure_notification(std::function<void(uint32_t)> notification)
-    {
-        configure_notifiers.push_back(notification);
-    }
+    MOCK_METHOD(void, configure, (uint32_t serial));
 
     operator zxdg_surface_v6*() const {return shell_surface;}
 
-    std::vector<std::function<void(uint32_t)>> configure_notifiers;
-
 private:
-    static void configure_thunk(void *data, struct zxdg_surface_v6 *, uint32_t serial)
-    {
-        for (auto& notifier : static_cast<XdgSurfaceV6*>(data)->configure_notifiers)
-        {
-            notifier(serial);
-        }
-    }
-
     zxdg_surface_v6* shell_surface;
 };
 
@@ -75,41 +64,13 @@ public:
     XdgToplevelV6& operator=(XdgToplevelV6 const&) = delete;
     ~XdgToplevelV6();
 
-    void add_configure_notification(std::function<void(int32_t, int32_t, struct wl_array *)> notification)
-    {
-        configure_notifiers.push_back(notification);
-    }
-
-    void add_close_notification(std::function<void()> notification)
-    {
-        close_notifiers.push_back(notification);
-    }
+    MOCK_METHOD(void, configure, (int32_t width, int32_t height, wl_array* states));
+    MOCK_METHOD(void, close, ());
 
     operator zxdg_toplevel_v6*() const {return toplevel;}
 
     XdgSurfaceV6* const shell_surface;
     zxdg_toplevel_v6* toplevel;
-
-    std::vector<std::function<void(int32_t, int32_t, struct wl_array *)>> configure_notifiers;
-    std::vector<std::function<void()>> close_notifiers;
-
-private:
-    static void configure_thunk(void *data, struct zxdg_toplevel_v6 *, int32_t width, int32_t height,
-                                struct wl_array *states)
-    {
-        for (auto& notifier : static_cast<XdgToplevelV6*>(data)->configure_notifiers)
-        {
-            notifier(width, height, states);
-        }
-    }
-
-    static void close_thunk(void *data, struct zxdg_toplevel_v6 *)
-    {
-        for (auto& notifier : static_cast<XdgToplevelV6*>(data)->close_notifiers)
-        {
-            notifier();
-        }
-    }
 };
 
 class XdgPositionerV6
@@ -131,41 +92,13 @@ public:
     XdgPopupV6& operator=(XdgPopupV6 const&) = delete;
     ~XdgPopupV6();
 
-    void add_configure_notification(std::function<void(int32_t, int32_t, int32_t, int32_t)> notification)
-    {
-        configure_notifiers.push_back(notification);
-    }
-
-    void add_close_notification(std::function<void()> notification)
-    {
-        popup_done_notifiers.push_back(notification);
-    }
+    MOCK_METHOD(void, configure, (int32_t x, int32_t y, int32_t width, int32_t height));
+    MOCK_METHOD(void, done, ());
 
     operator zxdg_popup_v6*() const {return popup;}
 
     XdgSurfaceV6* const shell_surface;
     zxdg_popup_v6* const popup;
-
-    std::vector<std::function<void(int32_t, int32_t, int32_t, int32_t)>> configure_notifiers;
-    std::vector<std::function<void()>> popup_done_notifiers;
-
-private:
-    static void configure_thunk(void *data, struct zxdg_popup_v6 *, int32_t x, int32_t y,
-                                int32_t width, int32_t height)
-    {
-        for (auto& notifier : static_cast<XdgPopupV6*>(data)->configure_notifiers)
-        {
-            notifier(x, y, width, height);
-        }
-    }
-
-    static void popup_done_thunk(void *data, struct zxdg_popup_v6 *)
-    {
-        for (auto& notifier : static_cast<XdgPopupV6*>(data)->popup_done_notifiers)
-        {
-            notifier();
-        }
-    }
 };
 
 }

--- a/src/xdg_shell_stable.cpp
+++ b/src/xdg_shell_stable.cpp
@@ -18,7 +18,7 @@
 
 #include "xdg_shell_stable.h"
 
-using namespace ::testing;
+using namespace testing;
 
 // XdgSurfaceStable
 

--- a/src/xdg_shell_stable.cpp
+++ b/src/xdg_shell_stable.cpp
@@ -18,14 +18,18 @@
 
 #include "xdg_shell_stable.h"
 
+using namespace ::testing;
+
 // XdgSurfaceStable
 
 wlcs::XdgSurfaceStable::XdgSurfaceStable(wlcs::Client& client, wlcs::Surface& surface)
 {
+    EXPECT_CALL(*this, configure).Times(AnyNumber());
     if (!client.xdg_shell_stable())
         throw std::runtime_error("XDG shell stable not supported by compositor");
     shell_surface = xdg_wm_base_get_xdg_surface(client.xdg_shell_stable(), surface);
-    static struct xdg_surface_listener const listener = {configure_thunk};
+    static struct xdg_surface_listener const listener = {
+        [](void* data, auto, auto... args) { static_cast<XdgSurfaceStable*>(data)->configure(args...); }};
     xdg_surface_add_listener(shell_surface, &listener, this);
 }
 
@@ -72,8 +76,12 @@ wlcs::XdgToplevelStable::State::State(int32_t width, int32_t height, struct wl_a
 wlcs::XdgToplevelStable::XdgToplevelStable(XdgSurfaceStable& shell_surface_)
     : shell_surface{&shell_surface_}
 {
+    EXPECT_CALL(*this, configure).Times(AnyNumber());
+    EXPECT_CALL(*this, close).Times(AnyNumber());
     toplevel = xdg_surface_get_toplevel(*shell_surface);
-    static struct xdg_toplevel_listener const listener = {configure_thunk, close_thunk};
+    static struct xdg_toplevel_listener const listener = {
+        [](void* data, auto, auto... args) { static_cast<XdgToplevelStable*>(data)->configure(args...); },
+        [](void* data, auto, auto... args) { static_cast<XdgToplevelStable*>(data)->close(args...); }};
     xdg_toplevel_add_listener(toplevel, &listener, this);
 }
 
@@ -102,7 +110,11 @@ wlcs::XdgPopupStable::XdgPopupStable(
           parent ? *parent.value() : (xdg_surface*)nullptr,
           positioner)}
 {
-    static struct xdg_popup_listener const listener = {configure_thunk, popup_done_thunk};
+    EXPECT_CALL(*this, configure).Times(AnyNumber());
+    EXPECT_CALL(*this, done).Times(AnyNumber());
+    static struct xdg_popup_listener const listener = {
+        [](void* data, auto, auto... args) { static_cast<XdgPopupStable*>(data)->configure(args...); },
+        [](void* data, auto, auto... args) { static_cast<XdgPopupStable*>(data)->done(args...); }};
     xdg_popup_add_listener(popup, &listener, this);
 }
 

--- a/tests/wlr_foreign_toplevel_management_v1.cpp
+++ b/tests/wlr_foreign_toplevel_management_v1.cpp
@@ -467,10 +467,9 @@ TEST_F(ForeignToplevelHandleTest, gets_activated)
 TEST_F(ForeignToplevelHandleTest, can_maximize_foreign)
 {
     wlcs::XdgToplevelStable::State state{0, 0, nullptr};
-    xdg_toplevel.add_configure_notification(
-        [&state](int32_t width, int32_t height, struct wl_array *states)
+    ON_CALL(xdg_toplevel, configure).WillByDefault([&state](auto... args)
         {
-            state = wlcs::XdgToplevelStable::State{width, height, states};
+            state = wlcs::XdgToplevelStable::State{args...};
         });
     xdg_toplevel_unset_maximized(xdg_toplevel);
     surface.attach_visible_buffer(w, h);
@@ -489,10 +488,9 @@ TEST_F(ForeignToplevelHandleTest, can_maximize_foreign)
 TEST_F(ForeignToplevelHandleTest, can_unmaximize_foreign)
 {
     wlcs::XdgToplevelStable::State state{0, 0, nullptr};
-    xdg_toplevel.add_configure_notification(
-        [&state](int32_t width, int32_t height, struct wl_array *states)
+    ON_CALL(xdg_toplevel, configure).WillByDefault([&state](auto... args)
         {
-            state = wlcs::XdgToplevelStable::State{width, height, states};
+            state = wlcs::XdgToplevelStable::State{args...};
         });
     xdg_toplevel_set_maximized(xdg_toplevel);
     surface.attach_visible_buffer(w, h);
@@ -511,10 +509,9 @@ TEST_F(ForeignToplevelHandleTest, can_unmaximize_foreign)
 TEST_F(ForeignToplevelHandleTest, can_fullscreen_foreign)
 {
     wlcs::XdgToplevelStable::State state{0, 0, nullptr};
-    xdg_toplevel.add_configure_notification(
-        [&state](int32_t width, int32_t height, struct wl_array *states)
+    ON_CALL(xdg_toplevel, configure).WillByDefault([&state](auto... args)
         {
-            state = wlcs::XdgToplevelStable::State{width, height, states};
+            state = wlcs::XdgToplevelStable::State{args...};
         });
     surface.attach_visible_buffer(w, h);
     client.roundtrip();
@@ -532,10 +529,9 @@ TEST_F(ForeignToplevelHandleTest, can_fullscreen_foreign)
 TEST_F(ForeignToplevelHandleTest, can_unfullscreen_foreign)
 {
     wlcs::XdgToplevelStable::State state{0, 0, nullptr};
-    xdg_toplevel.add_configure_notification(
-        [&state](int32_t width, int32_t height, struct wl_array *states)
+    ON_CALL(xdg_toplevel, configure).WillByDefault([&state](auto... args)
         {
-            state = wlcs::XdgToplevelStable::State{width, height, states};
+            state = wlcs::XdgToplevelStable::State{args...};
         });
     xdg_toplevel_set_fullscreen(xdg_toplevel, nullptr);
     surface.attach_visible_buffer(w, h);
@@ -624,10 +620,9 @@ TEST_F(ForeignToplevelHandleTest, can_unminimize_foreign)
 TEST_F(ForeignToplevelHandleTest, can_unminimize_foreign_to_restored)
 {
     wlcs::XdgToplevelStable::State state{0, 0, nullptr};
-    xdg_toplevel.add_configure_notification(
-        [&state](int32_t width, int32_t height, struct wl_array *states)
+    ON_CALL(xdg_toplevel, configure).WillByDefault([&state](auto... args)
         {
-            state = wlcs::XdgToplevelStable::State{width, height, states};
+            state = wlcs::XdgToplevelStable::State{args...};
         });
     surface.attach_visible_buffer(w, h);
     xdg_toplevel_unset_maximized(xdg_toplevel);
@@ -653,10 +648,9 @@ TEST_F(ForeignToplevelHandleTest, can_unminimize_foreign_to_restored)
 TEST_F(ForeignToplevelHandleTest, can_unminimize_foreign_to_maximized)
 {
     wlcs::XdgToplevelStable::State state{0, 0, nullptr};
-    xdg_toplevel.add_configure_notification(
-        [&state](int32_t width, int32_t height, struct wl_array *states)
+    ON_CALL(xdg_toplevel, configure).WillByDefault([&state](auto... args)
         {
-            state = wlcs::XdgToplevelStable::State{width, height, states};
+            state = wlcs::XdgToplevelStable::State{args...};
         });
     surface.attach_visible_buffer(w, h);
     xdg_toplevel_set_maximized(xdg_toplevel);
@@ -760,10 +754,9 @@ TEST_F(ForeignToplevelHandleTest, gets_unminimized_when_fullscreened)
 TEST_F(ForeignToplevelHandleTest, can_unfullscreen_foreign_to_restored)
 {
     wlcs::XdgToplevelStable::State state{0, 0, nullptr};
-    xdg_toplevel.add_configure_notification(
-        [&state](int32_t width, int32_t height, struct wl_array *states)
+    ON_CALL(xdg_toplevel, configure).WillByDefault([&state](auto... args)
         {
-            state = wlcs::XdgToplevelStable::State{width, height, states};
+            state = wlcs::XdgToplevelStable::State{args...};
         });
     xdg_toplevel_unset_maximized(xdg_toplevel);
     surface.attach_visible_buffer(w, h);
@@ -792,10 +785,9 @@ TEST_F(ForeignToplevelHandleTest, can_unfullscreen_foreign_to_restored)
 TEST_F(ForeignToplevelHandleTest, can_unfullscreen_foreign_to_maximized)
 {
     wlcs::XdgToplevelStable::State state{0, 0, nullptr};
-    xdg_toplevel.add_configure_notification(
-        [&state](int32_t width, int32_t height, struct wl_array *states)
+    ON_CALL(xdg_toplevel, configure).WillByDefault([&state](auto... args)
         {
-            state = wlcs::XdgToplevelStable::State{width, height, states};
+            state = wlcs::XdgToplevelStable::State{args...};
         });
     xdg_toplevel_set_maximized(xdg_toplevel);
     surface.attach_visible_buffer(w, h);
@@ -824,10 +816,9 @@ TEST_F(ForeignToplevelHandleTest, can_unfullscreen_foreign_to_maximized)
 TEST_F(ForeignToplevelHandleTest, can_maximize_foreign_while_fullscreen)
 {
     wlcs::XdgToplevelStable::State state{0, 0, nullptr};
-    xdg_toplevel.add_configure_notification(
-        [&state](int32_t width, int32_t height, struct wl_array *states)
+    ON_CALL(xdg_toplevel, configure).WillByDefault([&state](auto... args)
         {
-            state = wlcs::XdgToplevelStable::State{width, height, states};
+            state = wlcs::XdgToplevelStable::State{args...};
         });
     xdg_toplevel_unset_maximized(xdg_toplevel);
     surface.attach_visible_buffer(w, h);
@@ -863,10 +854,9 @@ TEST_F(ForeignToplevelHandleTest, can_maximize_foreign_while_fullscreen)
 TEST_F(ForeignToplevelHandleTest, can_activate_foreign)
 {
     wlcs::XdgToplevelStable::State state{0, 0, nullptr};
-    xdg_toplevel.add_configure_notification(
-        [&state](int32_t width, int32_t height, struct wl_array *states)
+    ON_CALL(xdg_toplevel, configure).WillByDefault([&state](auto... args)
         {
-            state = wlcs::XdgToplevelStable::State{width, height, states};
+            state = wlcs::XdgToplevelStable::State{args...};
         });
     std::string app_id = "fake.wlcs.app.id";
     xdg_toplevel_set_app_id(xdg_toplevel, app_id.c_str());
@@ -895,21 +885,15 @@ TEST_F(ForeignToplevelHandleTest, can_activate_foreign)
 
 TEST_F(ForeignToplevelHandleTest, can_close_foreign)
 {
-    bool should_close{false};
-    xdg_toplevel.add_close_notification(
-        [&should_close]()
-        {
-            should_close = true;
-        });
+    EXPECT_CALL(xdg_toplevel, close()).Times(0);
+
     surface.attach_visible_buffer(w, h);
     client.roundtrip();
 
-    EXPECT_THAT(should_close, Eq(false));
+    EXPECT_CALL(xdg_toplevel, close()).Times(1);
 
     zwlr_foreign_toplevel_handle_v1_close(toplevel());
     client.roundtrip();
-
-    EXPECT_THAT(should_close, Eq(true));
 }
 
 // TODO: test toplevel outputs

--- a/tests/wlr_layer_shell_v1.cpp
+++ b/tests/wlr_layer_shell_v1.cpp
@@ -870,7 +870,7 @@ TEST_P(LayerSurfaceLayoutTest, maximized_xdg_toplevel_is_shrunk_for_exclusive_zo
     wlcs::Surface other_surface{client};
     wlcs::XdgSurfaceStable xdg_surface{client, other_surface};
     wlcs::XdgToplevelStable toplevel{xdg_surface};
-    toplevel.add_configure_notification([&](int32_t w, int32_t h, wl_array* /*states*/)
+    ON_CALL(toplevel, configure).WillByDefault([&](auto w, auto h, wl_array* /*states*/)
         {
             if (w != width || h != height)
             {
@@ -884,7 +884,7 @@ TEST_P(LayerSurfaceLayoutTest, maximized_xdg_toplevel_is_shrunk_for_exclusive_zo
                 xdg_surface_set_window_geometry(xdg_surface, 0, 0, w, h);
             }
         });
-    xdg_surface.add_configure_notification([&](uint32_t serial)
+    ON_CALL(xdg_surface, configure).WillByDefault([&](uint32_t serial)
         {
             xdg_surface_ack_configure(xdg_surface, serial);
             wl_surface_commit(other_surface);
@@ -970,12 +970,12 @@ TEST_P(LayerSurfaceLayoutTest, simple_popup_positioned_correctly)
 
     int popup_surface_configure_count = 0;
     Vec2 popup_configured_position;
-    popup_xdg_surface.add_configure_notification([&](uint32_t serial)
+    ON_CALL(popup_xdg_surface, configure).WillByDefault([&](uint32_t serial)
         {
             xdg_surface_ack_configure(popup_xdg_surface, serial);
             popup_surface_configure_count++;
         });
-    popup_xdg_popup.add_configure_notification([&](int32_t x, int32_t y, int32_t, int32_t)
+    ON_CALL(popup_xdg_popup, configure).WillByDefault([&](int32_t x, int32_t y, int32_t, int32_t)
         {
             popup_configured_position.first = x;
             popup_configured_position.second = y;

--- a/tests/xdg_popup.cpp
+++ b/tests/xdg_popup.cpp
@@ -379,16 +379,15 @@ public:
             zxdg_popup_v6_grab(popup.value().popup, client.seat(), client.latest_serial().value());
         }
 
-        popup.value().add_close_notification([this](){ popup_done(); });
-        popup_xdg_surface.value().add_configure_notification([&](uint32_t serial)
+        ON_CALL(popup.value(), done).WillByDefault([this](){ popup_done(); });
+        ON_CALL(popup_xdg_surface.value(), configure).WillByDefault([&](auto serial)
             {
                 zxdg_surface_v6_ack_configure(popup_xdg_surface.value(), serial);
                 popup_surface_configure_count++;
             });
-
-        popup.value().add_configure_notification([this](int32_t x, int32_t y, int32_t width, int32_t height)
+        ON_CALL(popup.value(), configure).WillByDefault([this](auto... args)
             {
-                state = State{x, y, width, height};
+                state = State{args...};
             });
     }
 

--- a/tests/xdg_popup.cpp
+++ b/tests/xdg_popup.cpp
@@ -276,17 +276,16 @@ public:
             xdg_popup_grab(popup.value().popup, client.seat(), client.latest_serial().value());
         }
 
-        popup.value().add_close_notification([this](){ popup_done(); });
-        popup_xdg_surface.value().add_configure_notification([&](uint32_t serial)
+        ON_CALL(popup_xdg_surface.value(), configure).WillByDefault([&](auto serial)
             {
                 xdg_surface_ack_configure(popup_xdg_surface.value(), serial);
                 popup_surface_configure_count++;
             });
-
-        popup.value().add_configure_notification([this](int32_t x, int32_t y, int32_t width, int32_t height)
+        ON_CALL(popup.value(), configure).WillByDefault([&](auto... args)
             {
-                state = State{x, y, width, height};
+                state = State{args...};
             });
+        ON_CALL(popup.value(), done()).WillByDefault([this](){ popup_done(); });
     }
 
     void clear_popup() override
@@ -482,17 +481,16 @@ public:
             xdg_popup_grab(popup.value().popup, client.seat(), client.latest_serial().value());
         }
 
-        popup_xdg_surface.value().add_configure_notification([&](uint32_t serial)
+        ON_CALL(popup_xdg_surface.value(), configure).WillByDefault([&](uint32_t serial)
             {
                 xdg_surface_ack_configure(popup_xdg_surface.value(), serial);
                 popup_surface_configure_count++;
             });
-
-        popup.value().add_close_notification([this](){ popup_done(); });
-        popup.value().add_configure_notification([this](int32_t x, int32_t y, int32_t width, int32_t height)
+        ON_CALL(popup.value(), configure).WillByDefault([this](auto... args)
             {
-                state = State{x, y, width, height};
+                state = State{args...};
             });
+        ON_CALL(popup.value(), done()).WillByDefault([this](){ popup_done(); });
     }
 
     void clear_popup() override

--- a/tests/xdg_surface_stable.cpp
+++ b/tests/xdg_surface_stable.cpp
@@ -51,19 +51,16 @@ TEST_F(XdgSurfaceStableTest, gets_configure_event)
     wlcs::Surface surface{client};
     wlcs::XdgSurfaceStable xdg_surface{client, surface};
 
-    int surface_configure_count{0};
-    xdg_surface.add_configure_notification([&](uint32_t serial)
+    EXPECT_CALL(xdg_surface, configure)
+        .WillOnce([&](auto serial)
         {
             xdg_surface_ack_configure(xdg_surface, serial);
-            surface_configure_count++;
         });
 
     wlcs::XdgToplevelStable toplevel{xdg_surface};
     surface.attach_buffer(600, 400);
 
     client.roundtrip();
-
-    EXPECT_THAT(surface_configure_count, Eq(1));
 }
 
 TEST_F(XdgSurfaceStableTest, creating_xdg_surface_from_wl_surface_with_existing_role_is_an_error)

--- a/tests/xdg_surface_v6.cpp
+++ b/tests/xdg_surface_v6.cpp
@@ -48,17 +48,13 @@ TEST_F(XdgSurfaceV6Test, gets_configure_event)
     wlcs::Surface surface{client};
     wlcs::XdgSurfaceV6 xdg_surface{client, surface};
 
-    int surface_configure_count{0};
-    xdg_surface.add_configure_notification([&](uint32_t serial)
+    EXPECT_CALL(xdg_surface, configure).WillOnce([&](uint32_t serial)
         {
             zxdg_surface_v6_ack_configure(xdg_surface, serial);
-            surface_configure_count++;
         });
 
     wlcs::XdgToplevelV6 toplevel{xdg_surface};
     surface.attach_buffer(600, 400);
 
     client.roundtrip();
-
-    EXPECT_THAT(surface_configure_count, Eq(1));
 }

--- a/tests/xdg_toplevel_stable.cpp
+++ b/tests/xdg_toplevel_stable.cpp
@@ -48,15 +48,15 @@ public:
           xdg_shell_surface{client, surface},
           toplevel{xdg_shell_surface}
     {
-        xdg_shell_surface.add_configure_notification([&](uint32_t serial)
+        ON_CALL(xdg_shell_surface, configure).WillByDefault([&](auto serial)
             {
                 xdg_surface_ack_configure(xdg_shell_surface, serial);
                 surface_configure_count++;
             });
 
-        toplevel.add_configure_notification([this](int32_t width, int32_t height, struct wl_array *states)
+        ON_CALL(toplevel, configure).WillByDefault([&](auto... args)
             {
-                state = wlcs::XdgToplevelStable::State{width, height, states};
+                state = wlcs::XdgToplevelStable::State{args...};
             });
 
         wl_surface_commit(surface);

--- a/tests/xdg_toplevel_v6.cpp
+++ b/tests/xdg_toplevel_v6.cpp
@@ -48,15 +48,15 @@ public:
           xdg_surface{client, surface},
           toplevel{xdg_surface}
     {
-        xdg_surface.add_configure_notification([&](uint32_t serial)
+        ON_CALL(xdg_surface, configure).WillByDefault([&](auto serial)
             {
                 zxdg_surface_v6_ack_configure(xdg_surface, serial);
                 surface_configure_count++;
             });
 
-        toplevel.add_configure_notification([this](int32_t width, int32_t height, struct wl_array *states)
+        ON_CALL(toplevel, configure).WillByDefault([this](auto... args)
             {
-                state = wlcs::XdgToplevelV6::State{width, height, states};
+                state = wlcs::XdgToplevelV6::State{args...};
             });
 
         wl_surface_commit(surface);


### PR DESCRIPTION
Simplifies and standardizes how events are handled in XDG types