### PR TITLE
[RFC] Copy geometry headers from Mir

### DIFF
--- a/include/geometry/dimensions.h
+++ b/include/geometry/dimensions.h
@@ -14,8 +14,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MIR_GEOMETRY_DIMENSIONS_H_
-#define MIR_GEOMETRY_DIMENSIONS_H_
+#ifndef WLCS_GEOMETRY_DIMENSIONS_H_
+#define WLCS_GEOMETRY_DIMENSIONS_H_
 
 #include "forward.h"
 
@@ -23,9 +23,7 @@
 #include <type_traits>
 #include <cstdint>
 
-namespace mir
-{
-namespace geometry
+namespace wlcs
 {
 namespace generic
 {
@@ -255,7 +253,6 @@ template<typename T>
 inline constexpr generic::DeltaX<T> as_delta(generic::Width<T> const& w) { return generic::DeltaX<T>{w.as_value()}; }
 template<typename T>
 inline constexpr generic::DeltaY<T> as_delta(generic::Height<T> const& h) { return generic::DeltaY<T>{h.as_value()}; }
-} // namespace geometry
-} // namespace mir
+} // namespace wlcs
 
-#endif // MIR_GEOMETRY_DIMENSIONS_H_
+#endif // WLCS_GEOMETRY_DIMENSIONS_H_

--- a/include/geometry/dimensions.h
+++ b/include/geometry/dimensions.h
@@ -1,0 +1,261 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_GEOMETRY_DIMENSIONS_H_
+#define MIR_GEOMETRY_DIMENSIONS_H_
+
+#include "forward.h"
+
+#include <iosfwd>
+#include <type_traits>
+#include <cstdint>
+
+namespace mir
+{
+namespace geometry
+{
+namespace generic
+{
+template<typename T, typename Tag>
+/// Wraps a geometry value and prevents it from being accidentally used for invalid operations (such as setting a
+/// width to a height or adding two x positions together). Of course, explicit casts are possible to get around
+/// these restrictions (see the as_*() functions).
+struct Value
+{
+    using ValueType = T;
+    using TagType = Tag;
+
+    template <typename Q = T>
+    constexpr typename std::enable_if<std::is_integral<Q>::value, int>::type as_int() const
+    {
+        return this->value;
+    }
+
+    template <typename Q = T>
+    constexpr typename std::enable_if<std::is_integral<Q>::value, uint32_t>::type as_uint32_t() const
+    {
+        return this->value;
+    }
+
+    constexpr T as_value() const noexcept
+    {
+        return value;
+    }
+
+    constexpr Value() noexcept : value{} {}
+
+    Value& operator=(Value const& that) noexcept
+    {
+        value = that.value;
+        return *this;
+    }
+
+    constexpr Value(Value const& that) noexcept
+        : value{that.value}
+    {
+    }
+
+    template<typename U>
+    explicit constexpr Value(Value<U, Tag> const& value) noexcept
+        : value{static_cast<T>(value.as_value())}
+    {
+    }
+
+    template<typename U, typename std::enable_if<std::is_scalar<U>::value, bool>::type = true>
+    explicit constexpr Value(U const& value) noexcept
+        : value{static_cast<T>(value)}
+    {
+    }
+
+    inline constexpr auto operator == (Value<T, Tag> const& rhs) const -> bool
+    {
+        return value == rhs.as_value();
+    }
+
+    inline constexpr auto operator != (Value<T, Tag> const& rhs) const -> bool
+    {
+        return value != rhs.as_value();
+    }
+
+    inline constexpr auto operator <= (Value<T, Tag> const& rhs) const -> bool
+    {
+        return value <= rhs.as_value();
+    }
+
+    inline constexpr auto operator >= (Value<T, Tag> const& rhs) const -> bool
+    {
+        return value >= rhs.as_value();
+    }
+
+    inline constexpr auto operator < (Value<T, Tag> const& rhs) const -> bool
+    {
+        return value < rhs.as_value();
+    }
+
+    inline constexpr auto operator > (Value<T, Tag> const& rhs) const -> bool
+    {
+        return value > rhs.as_value();
+    }
+
+protected:
+    T value;
+};
+
+template<typename T, typename Tag>
+std::ostream& operator<<(std::ostream& out, Value<T, Tag> const& value)
+{
+    out << value.as_value();
+    return out;
+}
+
+// Adding deltas is fine
+template<typename T>
+inline constexpr DeltaX<T> operator+(DeltaX<T> lhs, DeltaX<T> rhs){ return DeltaX<T>(lhs.as_value() + rhs.as_value()); }
+template<typename T>
+inline constexpr DeltaY<T> operator+(DeltaY<T> lhs, DeltaY<T> rhs) { return DeltaY<T>(lhs.as_value() + rhs.as_value()); }
+template<typename T>
+inline constexpr DeltaX<T> operator-(DeltaX<T> lhs, DeltaX<T> rhs) { return DeltaX<T>(lhs.as_value() - rhs.as_value()); }
+template<typename T>
+inline constexpr DeltaY<T> operator-(DeltaY<T> lhs, DeltaY<T> rhs) { return DeltaY<T>(lhs.as_value() - rhs.as_value()); }
+template<typename T>
+inline constexpr DeltaX<T> operator-(DeltaX<T> rhs) { return DeltaX<T>(-rhs.as_value()); }
+template<typename T>
+inline constexpr DeltaY<T> operator-(DeltaY<T> rhs) { return DeltaY<T>(-rhs.as_value()); }
+template<typename T>
+inline DeltaX<T>& operator+=(DeltaX<T>& lhs, DeltaX<T> rhs) { return lhs = lhs + rhs; }
+template<typename T>
+inline DeltaY<T>& operator+=(DeltaY<T>& lhs, DeltaY<T> rhs) { return lhs = lhs + rhs; }
+template<typename T>
+inline DeltaX<T>& operator-=(DeltaX<T>& lhs, DeltaX<T> rhs) { return lhs = lhs - rhs; }
+template<typename T>
+inline DeltaY<T>& operator-=(DeltaY<T>& lhs, DeltaY<T> rhs) { return lhs = lhs - rhs; }
+
+// Adding deltas to co-ordinates is fine
+template<typename T>
+inline constexpr X<T> operator+(X<T> lhs, DeltaX<T> rhs) { return X<T>(lhs.as_value() + rhs.as_value()); }
+template<typename T>
+inline constexpr Y<T> operator+(Y<T> lhs, DeltaY<T> rhs) { return Y<T>(lhs.as_value() + rhs.as_value()); }
+template<typename T>
+inline constexpr X<T> operator-(X<T> lhs, DeltaX<T> rhs) { return X<T>(lhs.as_value() - rhs.as_value()); }
+template<typename T>
+inline constexpr Y<T> operator-(Y<T> lhs, DeltaY<T> rhs) { return Y<T>(lhs.as_value() - rhs.as_value()); }
+template<typename T>
+inline X<T>& operator+=(X<T>& lhs, DeltaX<T> rhs) { return lhs = lhs + rhs; }
+template<typename T>
+inline Y<T>& operator+=(Y<T>& lhs, DeltaY<T> rhs) { return lhs = lhs + rhs; }
+template<typename T>
+inline X<T>& operator-=(X<T>& lhs, DeltaX<T> rhs) { return lhs = lhs - rhs; }
+template<typename T>
+inline Y<T>& operator-=(Y<T>& lhs, DeltaY<T> rhs) { return lhs = lhs - rhs; }
+
+// Adding deltas to generic::Width and generic::Height is fine
+template<typename T>
+inline constexpr Width<T> operator+(Width<T> lhs, DeltaX<T> rhs) { return Width<T>(lhs.as_value() + rhs.as_value()); }
+template<typename T>
+inline constexpr Height<T> operator+(Height<T> lhs, DeltaY<T> rhs) { return Height<T>(lhs.as_value() + rhs.as_value()); }
+template<typename T>
+inline constexpr Width<T> operator-(Width<T> lhs, DeltaX<T> rhs) { return Width<T>(lhs.as_value() - rhs.as_value()); }
+template<typename T>
+inline constexpr Height<T> operator-(Height<T> lhs, DeltaY<T> rhs) { return Height<T>(lhs.as_value() - rhs.as_value()); }
+template<typename T>
+inline Width<T>& operator+=(Width<T>& lhs, DeltaX<T> rhs) { return lhs = lhs + rhs; }
+template<typename T>
+inline Height<T>& operator+=(Height<T>& lhs, DeltaY<T> rhs) { return lhs = lhs + rhs; }
+template<typename T>
+inline Width<T>& operator-=(Width<T>& lhs, DeltaX<T> rhs) { return lhs = lhs - rhs; }
+template<typename T>
+inline Height<T>& operator-=(Height<T>& lhs, DeltaY<T> rhs) { return lhs = lhs - rhs; }
+
+// Adding Widths and Heights is fine
+template<typename T>
+inline constexpr Width<T> operator+(Width<T> lhs, Width<T> rhs) { return Width<T>(lhs.as_value() + rhs.as_value()); }
+template<typename T>
+inline constexpr Height<T> operator+(Height<T> lhs, Height<T> rhs) { return Height<T>(lhs.as_value() + rhs.as_value()); }
+template<typename T>
+inline Width<T>& operator+=(Width<T>& lhs, Width<T> rhs) { return lhs = lhs + rhs; }
+template<typename T>
+inline Height<T>& operator+=(Height<T>& lhs, Height<T> rhs) { return lhs = lhs + rhs; }
+
+// Subtracting coordinates is fine
+template<typename T>
+inline constexpr DeltaX<T> operator-(X<T> lhs, X<T> rhs) { return DeltaX<T>(lhs.as_value() - rhs.as_value()); }
+template<typename T>
+inline constexpr DeltaY<T> operator-(Y<T> lhs, Y<T> rhs) { return DeltaY<T>(lhs.as_value() - rhs.as_value()); }
+
+//Subtracting Width<T> and Height<T> is fine
+template<typename T>
+inline constexpr DeltaX<T> operator-(Width<T> lhs, Width<T> rhs) { return DeltaX<T>(lhs.as_value() - rhs.as_value()); }
+template<typename T>
+inline constexpr DeltaY<T> operator-(Height<T> lhs, Height<T> rhs) { return DeltaY<T>(lhs.as_value() - rhs.as_value()); }
+
+// Multiplying by a scalar value is fine
+template<typename T, typename Scalar>
+inline constexpr Width<T> operator*(Scalar scale, Width<T> const& w) { return Width<T>{scale*w.as_value()}; }
+template<typename T, typename Scalar>
+inline constexpr Height<T> operator*(Scalar scale, Height<T> const& h) { return Height<T>{scale*h.as_value()}; }
+template<typename T, typename Scalar>
+inline constexpr DeltaX<T> operator*(Scalar scale, DeltaX<T> const& dx) { return DeltaX<T>{scale*dx.as_value()}; }
+template<typename T, typename Scalar>
+inline constexpr DeltaY<T> operator*(Scalar scale, DeltaY<T> const& dy) { return DeltaY<T>{scale*dy.as_value()}; }
+template<typename T, typename Scalar>
+inline constexpr Width<T> operator*(Width<T> const& w, Scalar scale) { return scale*w; }
+template<typename T, typename Scalar>
+inline constexpr Height<T> operator*(Height<T> const& h, Scalar scale) { return scale*h; }
+template<typename T, typename Scalar>
+inline constexpr DeltaX<T> operator*(DeltaX<T> const& dx, Scalar scale) { return scale*dx; }
+template<typename T, typename Scalar>
+inline constexpr DeltaY<T> operator*(DeltaY<T> const& dy, Scalar scale) { return scale*dy; }
+
+// Dividing by a scaler value is fine
+template<typename T, typename Scalar>
+inline constexpr Width<T> operator/(Width<T> const& w, Scalar scale) { return Width<T>{w.as_value() / scale}; }
+template<typename T, typename Scalar>
+inline constexpr Height<T> operator/(Height<T> const& h, Scalar scale) { return Height<T>{h.as_value() / scale}; }
+template<typename T, typename Scalar>
+inline constexpr DeltaX<T> operator/(DeltaX<T> const& dx, Scalar scale) { return DeltaX<T>{dx.as_value() / scale}; }
+template<typename T, typename Scalar>
+inline constexpr DeltaY<T> operator/(DeltaY<T> const& dy, Scalar scale) { return DeltaY<T>{dy.as_value() / scale}; }
+} // namespace
+
+// Converting between types is fine, as long as they are along the same axis
+template<typename T>
+inline constexpr generic::Width<T> as_width(generic::DeltaX<T> const& dx) { return generic::Width<T>{dx.as_value()}; }
+template<typename T>
+inline constexpr generic::Height<T> as_height(generic::DeltaY<T> const& dy) { return generic::Height<T>{dy.as_value()}; }
+template<typename T>
+inline constexpr generic::X<T> as_x(generic::DeltaX<T> const& dx) { return generic::X<T>{dx.as_value()}; }
+template<typename T>
+inline constexpr generic::Y<T> as_y(generic::DeltaY<T> const& dy) { return generic::Y<T>{dy.as_value()}; }
+template<typename T>
+inline constexpr generic::DeltaX<T> as_delta(generic::X<T> const& x) { return generic::DeltaX<T>{x.as_value()}; }
+template<typename T>
+inline constexpr generic::DeltaY<T> as_delta(generic::Y<T> const& y) { return generic::DeltaY<T>{y.as_value()}; }
+template<typename T>
+inline constexpr generic::X<T> as_x(generic::Width<T> const& w) { return generic::X<T>{w.as_value()}; }
+template<typename T>
+inline constexpr generic::Y<T> as_y(generic::Height<T> const& h) { return generic::Y<T>{h.as_value()}; }
+template<typename T>
+inline constexpr generic::Width<T> as_width(generic::X<T> const& x) { return generic::Width<T>{x.as_value()}; }
+template<typename T>
+inline constexpr generic::Height<T> as_height(generic::Y<T> const& y) { return generic::Height<T>{y.as_value()}; }
+template<typename T>
+inline constexpr generic::DeltaX<T> as_delta(generic::Width<T> const& w) { return generic::DeltaX<T>{w.as_value()}; }
+template<typename T>
+inline constexpr generic::DeltaY<T> as_delta(generic::Height<T> const& h) { return generic::DeltaY<T>{h.as_value()}; }
+} // namespace geometry
+} // namespace mir
+
+#endif // MIR_GEOMETRY_DIMENSIONS_H_

--- a/include/geometry/displacement.h
+++ b/include/geometry/displacement.h
@@ -1,0 +1,192 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_GEOMETRY_DISPLACEMENT_H_
+#define MIR_GEOMETRY_DISPLACEMENT_H_
+
+#include "forward.h"
+#include "dimensions.h"
+#include "point.h"
+#include <ostream>
+
+namespace mir
+{
+namespace geometry
+{
+namespace generic
+{
+template<typename T>
+struct Point;
+
+template<typename T>
+struct Size;
+
+template<typename T>
+struct Displacement
+{
+    using ValueType = T;
+
+    constexpr Displacement() {}
+    constexpr Displacement(Displacement const&) = default;
+    Displacement& operator=(Displacement const&) = default;
+
+    template<typename U>
+    explicit constexpr Displacement(Displacement<U> const& other) noexcept
+        : dx{DeltaX<T>{other.dx}},
+          dy{DeltaY<T>{other.dy}}
+    {
+    }
+
+    template<typename DeltaXType, typename DeltaYType>
+    constexpr Displacement(DeltaXType&& dx, DeltaYType&& dy) : dx{dx}, dy{dy} {}
+
+    template <typename Q = T>
+    constexpr typename std::enable_if<std::is_integral<Q>::value, long long>::type length_squared() const
+    {
+        long long x = dx.as_value(), y = dy.as_value();
+        return x * x + y * y;
+    }
+
+    template <typename Q = T>
+    constexpr typename std::enable_if<!std::is_integral<Q>::value, T>::type length_squared() const
+    {
+        T x = dx.as_value(), y = dy.as_value();
+        return x * x + y * y;
+    }
+
+    DeltaX<T> dx;
+    DeltaY<T> dy;
+};
+
+template<typename T>
+inline constexpr bool operator==(Displacement<T> const& lhs, Displacement<T> const& rhs)
+{
+    return lhs.dx == rhs.dx && lhs.dy == rhs.dy;
+}
+
+template<typename T>
+inline constexpr bool operator!=(Displacement<T> const& lhs, Displacement<T> const& rhs)
+{
+    return lhs.dx != rhs.dx || lhs.dy != rhs.dy;
+}
+
+template<typename T>
+std::ostream& operator<<(std::ostream& out, Displacement<T> const& value)
+{
+    out << '(' << value.dx << ", " << value.dy << ')';
+    return out;
+}
+
+template<typename T>
+inline constexpr Displacement<T> operator+(Displacement<T> const& lhs, Displacement<T> const& rhs)
+{
+    return Displacement<T>{lhs.dx + rhs.dx, lhs.dy + rhs.dy};
+}
+
+template<typename T>
+inline constexpr Displacement<T> operator-(Displacement<T> const& lhs, Displacement<T> const& rhs)
+{
+    return Displacement<T>{lhs.dx - rhs.dx, lhs.dy - rhs.dy};
+}
+
+template<typename T>
+inline constexpr Displacement<T> operator-(Displacement<T> const& rhs)
+{
+    return Displacement<T>{-rhs.dx, -rhs.dy};
+}
+
+template<typename T>
+inline constexpr Point<T> operator+(Point<T> const& lhs, Displacement<T> const& rhs)
+{
+    return Point<T>{lhs.x + rhs.dx, lhs.y + rhs.dy};
+}
+
+template<typename T>
+inline constexpr Point<T> operator+(Displacement<T> const& lhs, Point<T> const& rhs)
+{
+    return Point<T>{rhs.x + lhs.dx, rhs.y + lhs.dy};
+}
+
+template<typename T>
+inline constexpr Point<T> operator-(Point<T> const& lhs, Displacement<T> const& rhs)
+{
+    return Point<T>{lhs.x - rhs.dx, lhs.y - rhs.dy};
+}
+
+template<typename T>
+inline constexpr Displacement<T> operator-(Point<T> const& lhs, Point<T> const& rhs)
+{
+    return Displacement<T>{lhs.x - rhs.x, lhs.y - rhs.y};
+}
+
+template<typename T>
+inline constexpr Point<T>& operator+=(Point<T>& lhs, Displacement<T> const& rhs)
+{
+    return lhs = lhs + rhs;
+}
+
+template<typename T>
+inline constexpr Point<T>& operator-=(Point<T>& lhs, Displacement<T> const& rhs)
+{
+    return lhs = lhs - rhs;
+}
+
+template<typename T>
+inline bool operator<(Displacement<T> const& lhs, Displacement<T> const& rhs)
+{
+    return lhs.length_squared() < rhs.length_squared();
+}
+
+template<typename T, typename Scalar>
+inline constexpr Displacement<T> operator*(Scalar scale, Displacement<T> const& disp)
+{
+    return Displacement<T>{scale*disp.dx, scale*disp.dy};
+}
+
+template<typename T, typename Scalar>
+inline constexpr Displacement<T> operator*(Displacement<T> const& disp, Scalar scale)
+{
+    return scale*disp;
+}
+
+template<typename T>
+inline constexpr Displacement<T> as_displacement(Size<T> const& size)
+{
+    return Displacement<T>{size.width.as_value(), size.height.as_value()};
+}
+
+template<typename T>
+inline constexpr Size<T> as_size(Displacement<T> const& disp)
+{
+    return Size<T>{disp.dx.as_value(), disp.dy.as_value()};
+}
+
+template<typename T>
+inline constexpr Displacement<T> as_displacement(Point<T> const& point)
+{
+    return Displacement<T>{point.x.as_value(), point.y.as_value()};
+}
+
+template<typename T>
+inline constexpr Point<T> as_point(Displacement<T> const& disp)
+{
+    return Point<T>{disp.dx.as_value(), disp.dy.as_value()};
+}
+}
+}
+}
+
+#endif // MIR_GEOMETRY_DISPLACEMENT_H_

--- a/include/geometry/displacement.h
+++ b/include/geometry/displacement.h
@@ -14,17 +14,15 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MIR_GEOMETRY_DISPLACEMENT_H_
-#define MIR_GEOMETRY_DISPLACEMENT_H_
+#ifndef WLCS_GEOMETRY_DISPLACEMENT_H_
+#define WLCS_GEOMETRY_DISPLACEMENT_H_
 
 #include "forward.h"
 #include "dimensions.h"
 #include "point.h"
 #include <ostream>
 
-namespace mir
-{
-namespace geometry
+namespace wlcs
 {
 namespace generic
 {
@@ -187,6 +185,5 @@ inline constexpr Point<T> as_point(Displacement<T> const& disp)
 }
 }
 }
-}
 
-#endif // MIR_GEOMETRY_DISPLACEMENT_H_
+#endif // WLCS_GEOMETRY_DISPLACEMENT_H_

--- a/include/geometry/forward.h
+++ b/include/geometry/forward.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_GEOMETRY_FORWARD_H_
+#define MIR_GEOMETRY_FORWARD_H_
+
+namespace mir
+{
+/// Basic geometry types. Types for dimensions, displacements, etc.
+/// and the operations that they support.
+namespace geometry
+{
+/// These tag types determine what type of dimension a value holds and what operations are possible with it. They are
+/// only used as template parameters, are never instantiated and should only require forward declarations, but some
+/// compiler versions seem to fail if they aren't given real declarations.
+/// @{
+struct WidthTag{};
+struct HeightTag{};
+struct XTag{};
+struct YTag{};
+struct DeltaXTag{};
+struct DeltaYTag{};
+struct StrideTag{};
+/// @}
+
+namespace generic
+{
+template<typename T, typename Tag>
+struct Value;
+
+template<typename T>
+struct Point;
+
+template<typename T>
+struct Size;
+
+template<typename T>
+struct Displacement;
+
+template<typename T>
+struct Rectangle;
+
+template<typename T> using Width = Value<T, WidthTag>;
+template<typename T> using Height = Value<T, HeightTag>;
+template<typename T> using X = Value<T, XTag>;
+template<typename T> using Y = Value<T, YTag>;
+template<typename T> using DeltaX = Value<T, DeltaXTag>;
+template<typename T> using DeltaY = Value<T, DeltaYTag>;
+}
+
+using Width = generic::Width<int>;
+using Height = generic::Height<int>;
+using X = generic::X<int>;
+using Y = generic::Y<int>;
+using DeltaX = generic::DeltaX<int>;
+using DeltaY = generic::DeltaY<int>;
+
+using WidthF = generic::Width<float>;
+using HeightF = generic::Height<float>;
+using XF = generic::X<float>;
+using YF = generic::Y<float>;
+using DeltaXF = generic::DeltaX<float>;
+using DeltaYF = generic::DeltaY<float>;
+
+// Just to be clear, mir::geometry::Stride is the stride of the buffer in bytes
+using Stride = generic::Value<int, StrideTag>;
+
+using Point = generic::Point<int>;
+using Size = generic::Size<int>;
+using Displacement = generic::Displacement<int>;
+using Rectangle = generic::Rectangle<int>;
+
+using PointF = generic::Point<float>;
+using SizeF = generic::Size<float>;
+using DisplacementF = generic::Displacement<float>;
+using RectangleF = generic::Rectangle<int>;
+}
+}
+
+#endif // MIR_GEOMETRY_FORWARD_H_

--- a/include/geometry/forward.h
+++ b/include/geometry/forward.h
@@ -14,14 +14,10 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MIR_GEOMETRY_FORWARD_H_
-#define MIR_GEOMETRY_FORWARD_H_
+#ifndef WLCS_GEOMETRY_FORWARD_H_
+#define WLCS_GEOMETRY_FORWARD_H_
 
-namespace mir
-{
-/// Basic geometry types. Types for dimensions, displacements, etc.
-/// and the operations that they support.
-namespace geometry
+namespace wlcs
 {
 /// These tag types determine what type of dimension a value holds and what operations are possible with it. They are
 /// only used as template parameters, are never instantiated and should only require forward declarations, but some
@@ -88,6 +84,5 @@ using SizeF = generic::Size<float>;
 using DisplacementF = generic::Displacement<float>;
 using RectangleF = generic::Rectangle<int>;
 }
-}
 
-#endif // MIR_GEOMETRY_FORWARD_H_
+#endif // WLCS_GEOMETRY_FORWARD_H_

--- a/include/geometry/point.h
+++ b/include/geometry/point.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_GEOMETRY_POINT_H_
+#define MIR_GEOMETRY_POINT_H_
+
+#include "forward.h"
+#include "dimensions.h"
+#include <ostream>
+
+namespace mir
+{
+namespace geometry
+{
+namespace generic
+{
+template<typename T>
+struct Size;
+template<typename T>
+struct Displacement;
+
+template<typename T>
+struct Point
+{
+    using ValueType = T;
+
+    constexpr Point() = default;
+    constexpr Point(Point const&) = default;
+    Point& operator=(Point const&) = default;
+
+    template<typename U>
+    explicit constexpr Point(Point<U> const& other) noexcept
+        : x{X<T>{other.x}},
+          y{Y<T>{other.y}}
+    {
+    }
+
+    template<typename XType, typename YType>
+    constexpr Point(XType&& x, YType&& y) : x(x), y(y) {}
+
+    X<T> x;
+    Y<T> y;
+};
+
+template<typename T>
+inline constexpr bool operator == (Point<T> const& lhs, Point<T> const& rhs)
+{
+    return lhs.x == rhs.x && lhs.y == rhs.y;
+}
+
+template<typename T>
+inline constexpr bool operator != (Point<T> const& lhs, Point<T> const& rhs)
+{
+    return lhs.x != rhs.x || lhs.y != rhs.y;
+}
+
+template<typename T>
+inline constexpr Point<T> operator+(Point<T> lhs, DeltaX<T> rhs) { return{lhs.x + rhs, lhs.y}; }
+template<typename T>
+inline constexpr Point<T> operator+(Point<T> lhs, DeltaY<T> rhs) { return{lhs.x, lhs.y + rhs}; }
+
+template<typename T>
+inline constexpr Point<T> operator-(Point<T> lhs, DeltaX<T> rhs) { return{lhs.x - rhs, lhs.y}; }
+template<typename T>
+inline constexpr Point<T> operator-(Point<T> lhs, DeltaY<T> rhs) { return{lhs.x, lhs.y - rhs}; }
+
+template<typename T>
+inline Point<T>& operator+=(Point<T>& lhs, DeltaX<T> rhs) { lhs.x += rhs; return lhs; }
+template<typename T>
+inline Point<T>& operator+=(Point<T>& lhs, DeltaY<T> rhs) { lhs.y += rhs; return lhs; }
+
+template<typename T>
+inline Point<T>& operator-=(Point<T>& lhs, DeltaX<T> rhs) { lhs.x -= rhs; return lhs; }
+template<typename T>
+inline Point<T>& operator-=(Point<T>& lhs, DeltaY<T> rhs) { lhs.y -= rhs; return lhs; }
+
+template<typename T>
+std::ostream& operator<<(std::ostream& out, Point<T> const& value)
+{
+    out << value.x << ", " << value.y;
+    return out;
+}
+
+}
+}
+}
+
+#endif // MIR_GEOMETRY_POINT_H_

--- a/include/geometry/point.h
+++ b/include/geometry/point.h
@@ -14,16 +14,14 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MIR_GEOMETRY_POINT_H_
-#define MIR_GEOMETRY_POINT_H_
+#ifndef WLCS_GEOMETRY_POINT_H_
+#define WLCS_GEOMETRY_POINT_H_
 
 #include "forward.h"
 #include "dimensions.h"
 #include <ostream>
 
-namespace mir
-{
-namespace geometry
+namespace wlcs
 {
 namespace generic
 {
@@ -96,6 +94,5 @@ std::ostream& operator<<(std::ostream& out, Point<T> const& value)
 
 }
 }
-}
 
-#endif // MIR_GEOMETRY_POINT_H_
+#endif // WLCS_GEOMETRY_POINT_H_

--- a/include/geometry/rectangle.h
+++ b/include/geometry/rectangle.h
@@ -14,8 +14,8 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MIR_GEOMETRY_RECTANGLE_H_
-#define MIR_GEOMETRY_RECTANGLE_H_
+#ifndef WLCS_GEOMETRY_RECTANGLE_H_
+#define WLCS_GEOMETRY_RECTANGLE_H_
 
 #include "forward.h"
 #include "point.h"
@@ -24,9 +24,7 @@
 
 #include <ostream>
 
-namespace mir
-{
-namespace geometry
+namespace wlcs
 {
 namespace generic
 {
@@ -143,6 +141,5 @@ std::ostream& operator<<(std::ostream& out, Rectangle<T> const& value)
 }
 }
 }
-}
 
-#endif // MIR_GEOMETRY_RECTANGLE_H_
+#endif // WLCS_GEOMETRY_RECTANGLE_H_

--- a/include/geometry/rectangle.h
+++ b/include/geometry/rectangle.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_GEOMETRY_RECTANGLE_H_
+#define MIR_GEOMETRY_RECTANGLE_H_
+
+#include "forward.h"
+#include "point.h"
+#include "size.h"
+#include "displacement.h"
+
+#include <ostream>
+
+namespace mir
+{
+namespace geometry
+{
+namespace generic
+{
+template<typename T>
+struct Rectangle
+{
+    constexpr Rectangle() = default;
+
+    constexpr Rectangle(Point<T> const& top_left, Size<T> const& size)
+        : top_left{top_left}, size{size}
+    {
+    }
+
+    /**
+     * The bottom right boundary point of the rectangle.
+     *
+     * Note that the returned point is *not* included in the rectangle
+     * area, that is, the rectangle is represented as [top_left,bottom_right).
+     */
+    Point<T> bottom_right() const
+    {
+        return top_left + as_displacement(size);
+    }
+
+    Point<T> top_right() const
+    {
+        return top_left + as_delta(size.width);
+    }
+
+    Point<T> bottom_left() const
+    {
+        return top_left + as_delta(size.height);
+    }
+
+    bool contains(Point<T> const& p) const
+    {
+        if (size.width == decltype(size.width){} || size.height == decltype(size.height){})
+            return false;
+
+        auto br = bottom_right();
+        return p.x >= left() && p.x < br.x &&
+               p.y >= top() && p.y < br.y;
+    }
+
+    /**
+     * Test if the rectangle contains another.
+     *
+     * Note that an empty rectangle can still contain other empty rectangles,
+     * which are treated as points or lines of thickness zero.
+     */
+    bool contains(Rectangle<T> const& r) const
+    {
+        return r.left() >= left() &&
+               r.left() + as_delta(r.size.width) <= left() + as_delta(size.width) &&
+               r.top() >= top() &&
+               r.top() + as_delta(r.size.height) <= top() + as_delta(size.height);
+    }
+
+    bool overlaps(Rectangle<T> const& r) const
+    {
+        bool disjoint = r.left() >= right()
+                     || r.right() <= left()
+                     || r.top() >= bottom()
+                     || r.bottom() <= top()
+                     || size.width == decltype(size.width){}
+                     || size.height == decltype(size.height){}
+                     || r.size.width == decltype(r.size.width){}
+                     || r.size.height == decltype(r.size.height){};
+        return !disjoint;
+    }
+
+    X<T> left() const   { return top_left.x; }
+    X<T> right() const  { return bottom_right().x; }
+    Y<T> top() const    { return top_left.y; }
+    Y<T> bottom() const { return bottom_right().y; }
+
+    Point<T> top_left;
+    Size<T> size;
+};
+
+template<typename T>
+Rectangle<T> intersection_of(Rectangle<T> const& a, Rectangle<T> const& b)
+{
+    auto const max_left   = std::max(a.left(),   b.left());
+    auto const min_right  = std::min(a.right(),  b.right());
+    auto const max_top    = std::max(a.top(),    b.top());
+    auto const min_bottom = std::min(a.bottom(), b.bottom());
+
+    if (max_left < min_right && max_top < min_bottom)
+        return {{max_left, max_top},
+                {(min_right - max_left).as_value(),
+                (min_bottom - max_top).as_value()}};
+    else
+        return {};
+}
+
+template<typename T>
+inline constexpr bool operator == (Rectangle<T> const& lhs, Rectangle<T> const& rhs)
+{
+    return lhs.top_left == rhs.top_left && lhs.size == rhs.size;
+}
+
+template<typename T>
+inline constexpr bool operator != (Rectangle<T> const& lhs, Rectangle<T> const& rhs)
+{
+    return lhs.top_left != rhs.top_left || lhs.size != rhs.size;
+}
+
+template<typename T>
+std::ostream& operator<<(std::ostream& out, Rectangle<T> const& value)
+{
+    out << '(' << value.top_left << ", " << value.size << ')';
+    return out;
+}
+}
+}
+}
+
+#endif // MIR_GEOMETRY_RECTANGLE_H_

--- a/include/geometry/size.h
+++ b/include/geometry/size.h
@@ -14,16 +14,14 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MIR_GEOMETRY_SIZE_H_
-#define MIR_GEOMETRY_SIZE_H_
+#ifndef WLCS_GEOMETRY_SIZE_H_
+#define WLCS_GEOMETRY_SIZE_H_
 
 #include "forward.h"
 #include "dimensions.h"
 #include <ostream>
 
-namespace mir
-{
-namespace geometry
+namespace wlcs
 {
 namespace generic
 {
@@ -105,6 +103,5 @@ inline constexpr Point<T> as_point(Size<T> const& size)
 }
 }
 }
-}
 
-#endif // MIR_GEOMETRY_SIZE_H_
+#endif // WLCS_GEOMETRY_SIZE_H_

--- a/include/geometry/size.h
+++ b/include/geometry/size.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright © Canonical Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License version 2 or 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIR_GEOMETRY_SIZE_H_
+#define MIR_GEOMETRY_SIZE_H_
+
+#include "forward.h"
+#include "dimensions.h"
+#include <ostream>
+
+namespace mir
+{
+namespace geometry
+{
+namespace generic
+{
+template<typename T>
+struct Point;
+template<typename T>
+struct Displacement;
+
+template<typename T>
+struct Size
+{
+    using ValueType = T;
+
+    constexpr Size() noexcept {}
+    constexpr Size(Size const&) noexcept = default;
+    Size& operator=(Size const&) noexcept = default;
+
+    template<typename U>
+    explicit constexpr Size(Size<U> const& other) noexcept
+        : width{Width<T>{other.width}},
+          height{Height<T>{other.height}}
+    {
+    }
+
+    template<typename WidthType, typename HeightType>
+    constexpr Size(WidthType&& width, HeightType&& height) noexcept : width(width), height(height) {}
+
+    Width<T> width;
+    Height<T> height;
+};
+
+template<typename T>
+inline constexpr bool operator == (Size<T> const& lhs, Size<T> const& rhs)
+{
+    return lhs.width == rhs.width && lhs.height == rhs.height;
+}
+
+template<typename T>
+inline constexpr bool operator != (Size<T> const& lhs, Size<T> const& rhs)
+{
+    return lhs.width != rhs.width || lhs.height != rhs.height;
+}
+
+template<typename T>
+std::ostream& operator<<(std::ostream& out, Size<T> const& value)
+{
+    out << '(' << value.width << ", " << value.height << ')';
+    return out;
+}
+
+template<typename T, typename Scalar>
+inline constexpr Size<T> operator*(Scalar scale, Size<T> const& size)
+{
+    return Size<T>{scale*size.width, scale*size.height};
+}
+
+template<typename T, typename Scalar>
+inline constexpr Size<T> operator*(Size<T> const& size, Scalar scale)
+{
+    return scale*size;
+}
+
+template<typename T, typename Scalar>
+inline constexpr Size<T> operator/(Size<T> const& size, Scalar scale)
+{
+    return Size<T>{size.width / scale, size.height / scale};
+}
+
+template<typename T>
+inline constexpr Size<T> as_size(Point<T> const& point)
+{
+    return Size<T>{point.x.as_value(), point.y.as_value()};
+}
+
+template<typename T>
+inline constexpr Point<T> as_point(Size<T> const& size)
+{
+    return Point<T>{size.width.as_value(), size.height.as_value()};
+}
+}
+}
+}
+
+#endif // MIR_GEOMETRY_SIZE_H_

--- a/include/layer_shell_v1.h
+++ b/include/layer_shell_v1.h
@@ -21,6 +21,7 @@
 
 #include "in_process_server.h"
 #include "wl_handle.h"
+#include "geometry/size.h"
 
 // Because _someone_ *cough*ddevault*cough* thought it would be a great idea to name an argument "namespace"
 #ifdef __clang__
@@ -78,15 +79,13 @@ public:
     operator zwlr_layer_shell_v1*() const { return layer_shell; }
 
     void dispatch_until_configure();
-    auto last_width() const -> int { return last_width_; }
-    auto last_height() const -> int { return last_height_; }
+    auto last_size() const -> wlcs::Size { return last_size_; }
 
 private:
     wlcs::Client& client;
     WlHandle<zwlr_layer_shell_v1> layer_shell;
     WlHandle<zwlr_layer_surface_v1> layer_surface;
-    int last_width_ = -1;
-    int last_height_ = -1;
+    Size last_size_ = {-1, -1};
     int configure_count = 0;
 };
 

--- a/src/layer_shell_v1.cpp
+++ b/src/layer_shell_v1.cpp
@@ -44,8 +44,7 @@ wlcs::LayerSurfaceV1::LayerSurfaceV1(
             uint32_t height)
             {
                 auto self = static_cast<LayerSurfaceV1*>(data);
-                self->last_width_ = (int)width;
-                self->last_height_ = (int)height;
+                self->last_size_ = {width, height};
                 self->configure_count++;
                 (void)zwlr_layer_surface_v1;
                 (void)serial;


### PR DESCRIPTION
We've discussed doing this in the past, and the recent work I've done on popup positioning logic got especially annoying without some sort of proper geometry types. The complexity of the Mir ones is arguably overkill for wlcs (some might even argue overkill for Mir), but they're familiar to the Mir team and easy to use. I adapted the layer shell tests to show how they can be used in WLCS, but there's still a lot more work and code churn to fully use them.