### PR TITLE
Test buffer can be deleted after it's attached

### DIFF
--- a/tests/frame_submission.cpp
+++ b/tests/frame_submission.cpp
@@ -85,7 +85,16 @@ TEST_F(FrameSubmission, test_buffer_can_be_deleted_after_attached)
     auto buffer = std::make_shared<wlcs::ShmBuffer>(client, 200, 200);
     wl_surface_attach(surface, *buffer, 0, 0);
     buffer.reset();
+    /* Check that the destroyed buffer doesn't crash the server
+     * It's not clear what the *correct* behaviour is in this case:
+     * Weston treats this as committing a null buffer, wlroots appears to
+     * treat this as committing the content of the buffer before deletion.
+     *
+     * *Whatever* the correct behaviour is, "crash" is *definitely*
+     * incorrect.
+     */
     wl_surface_commit(surface);
 
+    // Roundtrip to ensure the server has processed our weirdness
     client.roundtrip();
 }

--- a/tests/frame_submission.cpp
+++ b/tests/frame_submission.cpp
@@ -73,3 +73,19 @@ TEST_F(FrameSubmission, post_one_frame_at_a_time)
         EXPECT_THAT(frame_consumed, Eq(true));
     }
 }
+
+// Regression test for https://github.com/MirServer/mir/issues/2960
+TEST_F(FrameSubmission, test_buffer_can_be_deleted_after_attached)
+{
+    using namespace testing;
+
+    wlcs::Client client{the_server()};
+    auto surface = client.create_visible_surface(200, 200);
+
+    auto buffer = std::make_shared<wlcs::ShmBuffer>(client, 200, 200);
+    wl_surface_attach(surface, *buffer, 0, 0);
+    buffer.reset();
+    wl_surface_commit(surface);
+
+    client.roundtrip();
+}


### PR DESCRIPTION
Tests https://github.com/MirServer/mir/issues/2960