### PR TITLE
Fix various frame-event misunderstandings

### DIFF
--- a/tests/frame_submission.cpp
+++ b/tests/frame_submission.cpp
@@ -50,7 +50,8 @@ void FrameSubmission::submit_frame(bool& consumed_flag)
 
     consumed_flag = false;
     wl_callback_add_listener(wl_surface_frame(surface), &frame_listener, &consumed_flag);
-    wl_surface_damage(surface, 0, 0, 200, 200);
+    auto buffer = std::make_shared<wlcs::ShmBuffer>(client, 200, 200);
+    wl_surface_attach(surface, *buffer, 0, 0);
     wl_surface_commit(surface);
 }
 

--- a/tests/frame_submission.cpp
+++ b/tests/frame_submission.cpp
@@ -107,7 +107,7 @@ TEST_F(FrameSubmission, test_buffer_can_be_deleted_after_attached)
  * ends up looping endlessly. If the compositor *doesn't* respond to the frame
  * request, Firefox decides not to draw anything. 🤷‍♀️
  */
-TEST_F(FrameSubmission, test_frame_callback_storm)
+TEST_F(FrameSubmission, when_client_endlessly_requests_frame_then_callbacks_are_throttled)
 {
     using namespace testing;
     using namespace std::chrono_literals;

--- a/tests/frame_submission.cpp
+++ b/tests/frame_submission.cpp
@@ -99,3 +99,48 @@ TEST_F(FrameSubmission, test_buffer_can_be_deleted_after_attached)
     // Roundtrip to ensure the server has processed our weirdness
     client.roundtrip();
 }
+
+/* Firefox has a lovely habit of sending an endless stream of
+ * wl_surface.frame() requests (maybe it's trying to estimate vsync?!)
+ *
+ * If a compositor responds immediately to the frame on commit, Firefox
+ * ends up looping endlessly. If the compositor *doesn't* respond to the frame
+ * request, Firefox decides not to draw anything. 🤷‍♀️
+ */
+TEST_F(FrameSubmission, test_frame_callback_storm)
+{
+    using namespace testing;
+    using namespace std::chrono_literals;
+
+    wlcs::Client annoying_client{the_server()};
+    auto surface = client.create_visible_surface(200, 200);
+
+    bool frame_callback_called{false};
+
+    wl_callback_listener const listener = {
+        .done = [](void* data, struct wl_callback* callback, [[maybe_unused]]uint32_t timestamp)
+        {
+            wl_callback_destroy(callback);
+
+            auto callback_called = static_cast<bool*>(data);
+            *callback_called = true;
+        }
+    };
+
+    auto const timeout = std::chrono::steady_clock::now() + 10s;
+
+    do
+    {
+        frame_callback_called = false;
+        wl_callback_add_listener(wl_surface_frame(surface), &listener, &frame_callback_called);
+        wl_surface_commit(surface);
+        client.roundtrip();
+            /* This roundtrip ensures the server has processed everything prior.
+             * In particular, if the server sends the frame callback in response to wl_surface.commit, that frame callback
+             * will have been processed by now.
+             */
+    }
+    while (frame_callback_called && std::chrono::steady_clock::now() < timeout);
+
+    EXPECT_THAT(std::chrono::steady_clock::now(), Lt(timeout)) << "Timed out looping in frame callback storm";
+}

--- a/tests/test_surface_events.cpp
+++ b/tests/test_surface_events.cpp
@@ -534,11 +534,18 @@ TEST_F(ClientSurfaceEventsTest, frame_timestamp_increases)
     usleep(10000);
 
     wl_surface_attach(surface, buffers[2], 0, 0);
+    surface.add_frame_callback(
+        [&](int time)
+        {
+            EXPECT_THAT(time, Gt(prev_frame_time));
+            prev_frame_time = time;
+            frame_callback_count++;
+        });
     wl_surface_commit(surface);
 
     client.dispatch_until([&frame_callback_count]()
         {
-            return frame_callback_count >= 2;
+            return frame_callback_count == 2;
         });
 }
 

--- a/tests/test_surface_events.cpp
+++ b/tests/test_surface_events.cpp
@@ -516,15 +516,18 @@ TEST_F(ClientSurfaceEventsTest, frame_timestamp_increases)
     wl_surface_attach(surface, buffers[0], 0, 0);
     wl_surface_attach(surface, buffers[1], 0, 0);
 
-    int prev_frame_time = 0;
+    uint32_t prev_frame_time = 0;
     int frame_callback_count = 0;
-    surface.add_frame_callback(
-        [&](int time)
+
+    auto const check_time_and_increment_count =
+        [&](uint32_t timestamp)
         {
-            EXPECT_THAT(time, Gt(prev_frame_time));
-            prev_frame_time = time;
+            EXPECT_THAT(timestamp, Gt(prev_frame_time));
+            prev_frame_time = timestamp;
             frame_callback_count++;
-        });
+        };
+
+    surface.add_frame_callback(check_time_and_increment_count);
     wl_surface_commit(surface);
 
     /**
@@ -534,13 +537,7 @@ TEST_F(ClientSurfaceEventsTest, frame_timestamp_increases)
     usleep(10000);
 
     wl_surface_attach(surface, buffers[2], 0, 0);
-    surface.add_frame_callback(
-        [&](int time)
-        {
-            EXPECT_THAT(time, Gt(prev_frame_time));
-            prev_frame_time = time;
-            frame_callback_count++;
-        });
+    surface.add_frame_callback(check_time_and_increment_count);
     wl_surface_commit(surface);
 
     client.dispatch_until([&frame_callback_count]()


### PR DESCRIPTION
Some of our tests have been incorrect because of misunderstandings of the behaviour of various Wayland concepts (damage only applies to pending buffers, a frame callback gets fired at most once, and so on).

Fix these, and while we're at it add an explicit test for the Firefox-endlessly-spins-without-rendering-anything scenario we were kinda accidentally testing (because we were repeatedly sending frame requests without actually submitting anything).

Closes: #292 