### PR TITLE
Fix frame_timestamp_increases *again*

### DIFF
--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -290,6 +290,12 @@ public:
 
     auto bind_if_supported(wl_interface const& interface, VersionSpecifier const& version) const -> void*;
 
+    /**
+     * Perform a `wl_display_roundtrip()`
+     *
+     * This blocks until all previous client requests have been processed
+     * by the server, and the client has processed any server responses.
+     */
     void roundtrip();
 
     /**

--- a/include/in_process_server.h
+++ b/include/in_process_server.h
@@ -292,6 +292,19 @@ public:
 
     void roundtrip();
 
+    /**
+     * Perform a `wl_display_flush()`
+     *
+     * This ensures all previous client requests have *actually* been
+     * sent to the server, but does not wait for any replies or process
+     * any incomming messages.
+     *
+     * \note    It is possible that the server receive buffer will be too
+     *          small to hold all the outgoing messages. This method does
+     *          not provide a way to detect this case.
+     */
+    void flush();
+
 private:
     class Impl;
     std::unique_ptr<Impl> const impl;

--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -1073,6 +1073,23 @@ public:
         }
     }
 
+    void client_flush()
+    {
+        if (wl_display_flush(display) == -1)
+        {
+            /* flush will return a (non-fatal) EAGAIN if the send buffer is
+             * full.
+             *
+             * We don't particularly want to care about the EAGAIN case
+             * at the moment, so just ignore it.
+             */
+            if (errno != EAGAIN)
+            {
+                throw_wayland_error(display);
+            }
+        }
+    }
+
     struct Output
     {
         OutputState current;
@@ -1818,6 +1835,11 @@ void wlcs::Client::dispatch_until(std::function<bool()> const& predicate, std::c
 void wlcs::Client::roundtrip()
 {
     impl->server_roundtrip();
+}
+
+void wlcs::Client::flush()
+{
+    impl->client_flush();
 }
 
 void* wlcs::Client::bind_if_supported(wl_interface const& interface, VersionSpecifier const& version) const

--- a/tests/test_surface_events.cpp
+++ b/tests/test_surface_events.cpp
@@ -530,6 +530,11 @@ TEST_F(ClientSurfaceEventsTest, frame_timestamp_increases)
     surface.add_frame_callback(check_time_and_increment_count);
     wl_surface_commit(surface);
 
+    /* We don't need to wait for the server, but we *do* need
+     * the server to see this commit
+     */
+    client.flush();
+
     /**
      * We need to sleep for multiple miliseconds to make sure the timestamp
      * really does go up

--- a/tests/test_surface_events.cpp
+++ b/tests/test_surface_events.cpp
@@ -500,6 +500,7 @@ TEST_F(ClientSurfaceEventsTest, surface_moves_while_under_pointer)
 TEST_F(ClientSurfaceEventsTest, frame_timestamp_increases)
 {
     using namespace testing;
+    using namespace std::chrono_literals;
 
     wlcs::Client client{the_server()};
 
@@ -546,7 +547,7 @@ TEST_F(ClientSurfaceEventsTest, frame_timestamp_increases)
      * things easier for the integration by waiting a simulated
      * refresh cycle (at 60Hz) before submitting the next buffer.
      */
-    std::this_thread::sleep_for(std::chrono::milliseconds{17});
+    std::this_thread::sleep_for(std::chrono::ceil<std::chrono::milliseconds>(1.0s/60));
 
     wl_surface_attach(surface, buffers[2], 0, 0);
     surface.add_frame_callback(check_time_and_increment_count);

--- a/tests/test_surface_events.cpp
+++ b/tests/test_surface_events.cpp
@@ -30,6 +30,8 @@
 
 #include <deque>
 #include <tuple>
+#include <thread>
+#include <chrono>
 
 #include <gmock/gmock.h>
 
@@ -536,10 +538,15 @@ TEST_F(ClientSurfaceEventsTest, frame_timestamp_increases)
     client.flush();
 
     /**
-     * We need to sleep for multiple miliseconds to make sure the timestamp
-     * really does go up
+     * When run against a *real* compositor we should not need any
+     * delay here - when running on a real display, we would expect
+     * the second commit to wait for the next refresh cycle.
+     *
+     * But we're probably not running on a real display, so make
+     * things easier for the integration by waiting a simulated
+     * refresh cycle (at 60Hz) before submitting the next buffer.
      */
-    usleep(10000);
+    std::this_thread::sleep_for(std::chrono::milliseconds{17});
 
     wl_surface_attach(surface, buffers[2], 0, 0);
     surface.add_frame_callback(check_time_and_increment_count);


### PR DESCRIPTION
It turns out that this test was (incorrectly!) marked at XFAIL in Mir's CI. Incorrectly, because Mir actually *does* implement the necessary behaviour.

So Mir CI started to fail, because the XFAIL test was passing. But only sometimes, because it turns out the test was flaky - depending on whether or not `libwayland` felt like actually writing the requests into the display socket or not.