### PR TITLE
wlcs::Client: Handle incomplete logical pointer/touch events better.

### DIFF
--- a/src/in_process_server.cpp
+++ b/src/in_process_server.cpp
@@ -878,8 +878,6 @@ public:
 
     wl_surface* window_under_cursor() const
     {
-        if (pointer_events_pending())
-            BOOST_THROW_EXCEPTION(std::runtime_error("Pointer events pending"));
         if (current_pointer_location)
         {
             return current_pointer_location->surface;
@@ -889,8 +887,6 @@ public:
 
     wl_surface* touched_window() const
     {
-        if (touch_events_pending())
-            BOOST_THROW_EXCEPTION(std::runtime_error("Touch events pending"));
         wl_surface* surface = nullptr;
         for (auto const& touch : current_touches)
         {
@@ -904,15 +900,11 @@ public:
 
     std::pair<wl_fixed_t, wl_fixed_t> pointer_position() const
     {
-        if (pointer_events_pending())
-            BOOST_THROW_EXCEPTION(std::runtime_error("Pointer events pending"));
         return current_pointer_location.value().coordinates;
     };
 
     std::pair<wl_fixed_t, wl_fixed_t> touch_position() const
     {
-        if (touch_events_pending())
-            BOOST_THROW_EXCEPTION(std::runtime_error("Touch events pending"));
         if (current_touches.empty())
             BOOST_THROW_EXCEPTION(std::runtime_error("No touches"));
         else if (current_touches.size() == 1)


### PR DESCRIPTION
A sequence of `wl_pointer`/`wl_touch` events are combined into a logical event by the terminating `frame` event. When tests ask for the current touch/pointer position, or window under touch/pointer, always return the current state, even if there is an incomplete logical event (ie: some events have been received, but not a terminating `frame` event).

There's no guarantee that a compositor will emit a complete logical event in a single flush of the protocol socket, so there's no guarantee that we won't run test code after receiving (for example) a `wl_pointer.enter` event but before processing a `wl_pointer.frame`.

So it is incorrect to fail the test in such cases