### PR TITLE
debian: drop gcc-12 workaround

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -24,16 +24,6 @@ ifeq ($(DEB_HOST_ARCH), riscv64)
   COMMON_CONFIGURE_OPTIONS += -DWLCS_BUILD_TSAN=OFF
 endif
 
-# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105329
-ifeq ($(DEB_HOST_ARCH), ppc64el)
-  ifneq ($(shell gcc --version | grep '12.[[:digit:]]\+.[[:digit:]]\+$$'),)
-    export DEB_CFLAGS_MAINT_APPEND = -O2
-    export DEB_CXXFLAGS_MAINT_APPEND = -O2
-    export DEB_FCFLAGS_MAINT_APPEND = -O2
-    export DEB_FFLAGS_MAINT_APPEND = -O2
-  endif
-endif
-
 override_dh_auto_configure:
 	dh_auto_configure -- $(COMMON_CONFIGURE_OPTIONS)
 


### PR DESCRIPTION
The remaining issue is #314, with which this doesn't help anyway.