### PR TITLE
XdgToplevelStable: Accept more protocol-compliant behaviour.

### DIFF
--- a/tests/xdg_toplevel_stable.cpp
+++ b/tests/xdg_toplevel_stable.cpp
@@ -75,12 +75,17 @@ public:
 
         surface.attach_buffer(window_width, window_height);
         wl_surface_commit(surface);
+        client.flush();
 
         /* Now that we've committed a buffer (and hence should be mapped) we expect
-         * to be reconfigured with new state - particularly, we expect to be
-         * in “activated” state after this.
+         * that our surface will be active. Mir (and GNOME) send a second configure
+         * event after the initial buffer submitted, but this isn't mandated by
+         * the protocol.
+         *
+         * Instead, wait until we're in the “activated” state, as WLCS makes the
+         * assumption that newly-mapped windows are active.
          */
-        dispatch_until_configure();
+        client.dispatch_until([this]() { return state.activated; });
     }
 
     void dispatch_until_configure()


### PR DESCRIPTION
We assumed that the compositor would send a second `xdg_surface.configure` after committing a buffer, as now that the surface is mapped we expect it to be in the `activated` state.

This second configure isn't guaranteed by the protocol, and there's no reason a compositor couldn't set the `activated` state in the *first* `configure`, prior to the window being mapped, on the basis that it'll almost certainly be made active once it *has* been mapped¹.

Instead of waiting for a second configure, wait for the surface to be in `activated` state. That catches both, equally protocol compliant, compositor behaviours.

Fixes: #318 (again!)

¹: This is possibly desirable behaviour - this way the client can immediately draw in the activated state, rather than rendering for an inactive window and then immediately needing to re-render for an active window.