### PR TITLE
Release 1.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.5)
 cmake_policy(SET CMP0015 NEW)
 cmake_policy(SET CMP0022 NEW)
 
-project(wlcs VERSION 1.6.1)
+project(wlcs VERSION 1.7.0)
 
 add_definitions(-D_GNU_SOURCE)
 add_definitions(-D_FILE_OFFSET_BITS=64)

--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,7 @@ wlcs (1.7.0-0ubuntu0) UNRELEASED; urgency=medium
     + XdgToplevelStable: Fix race in .configure handling (#318)
     + helpers: avoid triggering a kernel warning (#320)
     + InProcessServer: Fix xdg_shell window construction (#324)
+    + XdgSurfaceStable: Fix configure event logic
 
  -- Michał Sawicz <michal.sawicz@canonical.com>  Tue, 05 Dec 2023 13:52:28 +0100
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,7 @@ wlcs (1.7.0-0ubuntu0) UNRELEASED; urgency=medium
     + Handle incomplete logical pointer/touch events better (#313)
     + XdgToplevelStable: Fix race in .configure handling (#318)
     + helpers: avoid triggering a kernel warning (#320)
+    + InProcessServer: Fix xdg_shell window construction (#324)
 
  -- Michał Sawicz <michal.sawicz@canonical.com>  Tue, 05 Dec 2023 13:52:28 +0100
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+wlcs (1.7.0-0ubuntu0) UNRELEASED; urgency=medium
+
+  * New upstream release. Notable changes:
+    + New tests for input-method-v1 (#302)
+    + Handle incomplete logical pointer/touch events better (#313)
+    + XdgToplevelStable: Fix race in .configure handling (#318)
+    + helpers: avoid triggering a kernel warning (#320)
+
+ -- Michał Sawicz <michal.sawicz@canonical.com>  Tue, 05 Dec 2023 13:52:28 +0100
+
 wlcs (1.6.1-0ubuntu0) UNRELEASED; urgency=medium
 
   * Bump project version in CMakeLists.txt

--- a/tests/xdg_surface_stable.cpp
+++ b/tests/xdg_surface_stable.cpp
@@ -51,16 +51,19 @@ TEST_F(XdgSurfaceStableTest, gets_configure_event)
     wlcs::Surface surface{client};
     wlcs::XdgSurfaceStable xdg_surface{client, surface};
 
+    bool configure_received{false};
     EXPECT_CALL(xdg_surface, configure)
         .WillOnce([&](auto serial)
         {
             xdg_surface_ack_configure(xdg_surface, serial);
+            configure_received = true;
         });
 
     wlcs::XdgToplevelStable toplevel{xdg_surface};
-    surface.attach_buffer(600, 400);
+    // The first commit triggers an initial xdg_surface.configure event
+    wl_surface_commit(surface);
 
-    client.roundtrip();
+    client.dispatch_until([&configure_received]() { return configure_received;} );
 }
 
 TEST_F(XdgSurfaceStableTest, creating_xdg_surface_from_wl_surface_with_existing_role_is_an_error)


### PR DESCRIPTION
  * New upstream release. Notable changes:
    + New tests for input-method-v1 (#302)
    + Handle incomplete logical pointer/touch events better (#313)
    + XdgToplevelStable: Fix race in .configure handling (#318)
    + helpers: avoid triggering a kernel warning (#320)
    + InProcessServer: Fix xdg_shell window construction (#324)
    + XdgSurfaceStable: Fix configure event logic (#322)